### PR TITLE
Move default implementation to NamingStrategy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,9 +4,9 @@
 
 	<modelVersion>4.0.0</modelVersion>
 
-    <groupId>org.springframework.data</groupId>
-    <artifactId>spring-data-jdbc</artifactId>
-    <version>1.0.0.BUILD-SNAPSHOT</version>
+	<groupId>org.springframework.data</groupId>
+	<artifactId>spring-data-jdbc</artifactId>
+	<version>1.0.0.BUILD-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -26,15 +26,15 @@
 		<java-module-name>spring.data.jdbc</java-module-name>
 		<sonar.dynamicAnalysis>reuseReports</sonar.dynamicAnalysis>
 
-        <assertj-core.version>3.6.2</assertj-core.version>
-        <degraph-check.version>0.1.4</degraph-check.version>
-        <hsqldb.version>2.2.8</hsqldb.version>
-        <mybatis.version>3.4.4</mybatis.version>
-        <mybatis-spring.version>1.3.1</mybatis-spring.version>
-        <mysql.version>1.5.1</mysql.version>
-        <mysql-connector-java.version>5.1.41</mysql-connector-java.version>
-        <postgresql.version>42.0.0</postgresql.version>
-    </properties>
+		<assertj-core.version>3.6.2</assertj-core.version>
+		<degraph-check.version>0.1.4</degraph-check.version>
+		<hsqldb.version>2.2.8</hsqldb.version>
+		<mybatis.version>3.4.4</mybatis.version>
+		<mybatis-spring.version>1.3.1</mybatis-spring.version>
+		<mysql.version>1.5.1</mysql.version>
+		<mysql-connector-java.version>5.1.41</mysql-connector-java.version>
+		<postgresql.version>42.0.0</postgresql.version>
+	</properties>
 
 	<profiles>
 		<profile>

--- a/src/main/java/org/springframework/data/jdbc/mapping/model/DefaultNamingStrategy.java
+++ b/src/main/java/org/springframework/data/jdbc/mapping/model/DefaultNamingStrategy.java
@@ -23,41 +23,8 @@ package org.springframework.data.jdbc.mapping.model;
  * a different strategy on the fly.
  *
  * @author Greg Turnquist
+ * @author Michael Simons
+ * @deprecated Use {@link NamingStrategy} for a default implementation and implement methods as needed
  */
 public class DefaultNamingStrategy implements NamingStrategy {
-
-	/**
-	 * No schema at all!
-	 */
-	@Override
-	public String getSchema() {
-		return "";
-	}
-
-	/**
-	 * Look up the {@link Class}'s simple name.
-	 */
-	@Override
-	public String getTableName(Class<?> type) {
-		return type.getSimpleName();
-	}
-
-
-	/**
-	 * Look up the {@link JdbcPersistentProperty}'s name.
-	 */
-	@Override
-	public String getColumnName(JdbcPersistentProperty property) {
-		return property.getName();
-	}
-
-	@Override
-	public String getReverseColumnName(JdbcPersistentProperty property) {
-		return property.getOwner().getTableName();
-	}
-
-	@Override
-	public String getKeyColumn(JdbcPersistentProperty property) {
-		return getReverseColumnName(property) + "_key";
-	}
 }

--- a/src/main/java/org/springframework/data/jdbc/mapping/model/NamingStrategy.java
+++ b/src/main/java/org/springframework/data/jdbc/mapping/model/NamingStrategy.java
@@ -16,31 +16,60 @@
 package org.springframework.data.jdbc.mapping.model;
 
 /**
+ * Interface and default implementation of a naming strategy. Defaults to no schema, 
+ * table name based on {@link Class} and column name based on {@link JdbcPersistentProperty}.
+ *
+ * NOTE: Can also be used as an adapter. Create a lambda or an anonymous subclass and 
+ * override any settings to implement a different strategy on the fly.
+ * 
  * @author Greg Turnquist
+ * @author Michael Simons
  */
 public interface NamingStrategy {
 
-	String getSchema();
+	/**
+	 * Defaults to no schema.
+	 *
+	 * @return No schema
+	 */
+	default String getSchema() {
+		return "";
+	}
 
-	String getTableName(Class<?> type);
+	/**
+	 * Look up the {@link Class}'s simple name.
+	 */
+	default String getTableName(Class<?> type) {
+		return type.getSimpleName();
+	}
 
-	String getColumnName(JdbcPersistentProperty property);
+	/**
+	 * Look up the {@link JdbcPersistentProperty}'s name.
+	 */
+	default String getColumnName(JdbcPersistentProperty property) {
+		return property.getName();
+	}
 
 	default String getQualifiedTableName(Class<?> type) {
 		return this.getSchema() + (this.getSchema().equals("") ? "" : ".") + this.getTableName(type);
 	}
 
 	/**
-	 * For a reference A -> B this is the name in the table for B which references A.
+	 * For a reference A -&gt; B this is the name in the table for B which references A.
 	 *
+	 * @param property The property who's column name in the owner table is required
 	 * @return a column name.
 	 */
-	String getReverseColumnName(JdbcPersistentProperty property);
+	default String getReverseColumnName(JdbcPersistentProperty property) {
+		return property.getOwner().getTableName();
+	}
 
 	/**
 	 * For a map valued reference A -> Map&gt;X,B&lt; this is the name of the column in the tabel for B holding the key of the map.
 	 * @return
 	 */
-	String getKeyColumn(JdbcPersistentProperty property);
+	default String getKeyColumn(JdbcPersistentProperty property){
+		return getReverseColumnName(property) + "_key";
+	}
 
 }


### PR DESCRIPTION
This makes it nicer to overwrite certain aspects with a lambda instead of an anonymous class. Brings the naming strategy in line with pairs like WebMvcConfigurer / WebMvcConfigurerAdapter.