### PR TITLE
DATAJDBC-164 - Support entity type and Stream as return type of @Query method

### DIFF
--- a/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryQuery.java
+++ b/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryQuery.java
@@ -53,7 +53,11 @@ class JdbcRepositoryQuery implements RepositoryQuery {
 			parameters.addValue(parameterName, objects[p.getIndex()]);
 		});
 
-		return context.getTemplate().query(query, parameters, rowMapper);
+		if (queryMethod.isCollectionQuery() || queryMethod.isStreamQuery()) {
+			return context.getTemplate().query(query, parameters, rowMapper);
+		} else {
+			return context.getTemplate().queryForObject(query, parameters, rowMapper);
+		}
 	}
 
 	@Override


### PR DESCRIPTION
In current implementation, the `@Query` method does not support entity type(or `Optional`), `Stream`, `Page`, `Slice` as return type.

At first , I will propose to support entity type and `Stream` . (I think better that `Page` and `Slice` will consider at next step)

WDYT?

