### PR TITLE
DATAJDBC-181 - Use NamingStrategy for instantiating entities.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.springframework.data</groupId>
     <artifactId>spring-data-jdbc</artifactId>
-    <version>1.0.0.BUILD-SNAPSHOT</version>
+    <version>1.0.0.DATAJDBC-181-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>

--- a/src/test/java/org/springframework/data/jdbc/core/EntityRowMapperUnitTests.java
+++ b/src/test/java/org/springframework/data/jdbc/core/EntityRowMapperUnitTests.java
@@ -319,7 +319,6 @@ public class EntityRowMapperUnitTests {
 		String name;
 	}
 
-	@RequiredArgsConstructor
 	static class OneToOne {
 
 		@Id
@@ -328,7 +327,6 @@ public class EntityRowMapperUnitTests {
 		Trivial child;
 	}
 
-	@RequiredArgsConstructor
 	static class OneToSet {
 
 		@Id
@@ -337,7 +335,6 @@ public class EntityRowMapperUnitTests {
 		Set<Trivial> children;
 	}
 
-	@RequiredArgsConstructor
 	static class OneToMap {
 
 		@Id
@@ -346,7 +343,6 @@ public class EntityRowMapperUnitTests {
 		Map<String, Trivial> children;
 	}
 
-	@RequiredArgsConstructor
 	static class OneToList {
 
 		@Id


### PR DESCRIPTION
The ResultSetParameterValueProvider uses the relevant property for a requested parameter in order to obtain the proper column name to use.

Improved mocking of ResultSets in tests to actually fail when a non-existing column gets requested instead of just returning null.