### PR TITLE
DATAJDBC-190 - Polishing to use the Assertions's method on test class

### DIFF
--- a/src/test/java/org/springframework/data/jdbc/mapping/model/BasicJdbcPersistentEntityInformationUnitTests.java
+++ b/src/test/java/org/springframework/data/jdbc/mapping/model/BasicJdbcPersistentEntityInformationUnitTests.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.data.jdbc.mapping.model;
 
-import static org.assertj.core.api.Java6Assertions.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import org.junit.Test;

--- a/src/test/java/org/springframework/data/jdbc/mapping/model/BasicJdbcPersistentPropertyUnitTests.java
+++ b/src/test/java/org/springframework/data/jdbc/mapping/model/BasicJdbcPersistentPropertyUnitTests.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.data.jdbc.mapping.model;
 
-import static org.assertj.core.api.AssertionsForClassTypes.*;
+import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import lombok.Data;
@@ -24,7 +24,6 @@ import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.Date;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.springframework.data.mapping.PropertyHandler;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
@@ -54,7 +53,7 @@ public class BasicJdbcPersistentPropertyUnitTests {
 					assertThat(p.getColumnType()).isEqualTo(String.class);
 					break;
 				default:
-					Assertions.fail("property with out assert: " + p.getName());
+					fail("property with out assert: " + p.getName());
 			}
 		});
 


### PR DESCRIPTION
I've changed to use the method of `org.assertj.core.api.Assertions`.