### PR TITLE
DATAJDBC-183 - Using dedicated class for handling map entries.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.springframework.data</groupId>
     <artifactId>spring-data-jdbc</artifactId>
-    <version>1.0.0.BUILD-SNAPSHOT</version>
+    <version>1.0.0.DATAJDBC-183-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>

--- a/src/main/java/org/springframework/data/jdbc/core/conversion/JdbcEntityWriter.java
+++ b/src/main/java/org/springframework/data/jdbc/core/conversion/JdbcEntityWriter.java
@@ -78,13 +78,13 @@ public class JdbcEntityWriter extends JdbcEntityWriterSupport {
 			Update<Object> update = DbAction.update(o, propertyPath, dependingOn);
 			aggregateChange.addAction(update);
 
-			referencedEntities(o).forEach(
-					propertyAndValue -> insertReferencedEntities(propertyAndValue, aggregateChange, propertyPath.nested(propertyAndValue.property.getName()), update));
+			referencedEntities(o).forEach(propertyAndValue -> insertReferencedEntities(propertyAndValue, aggregateChange,
+					propertyPath.nested(propertyAndValue.property.getName()), update));
 		}
 	}
 
 	private void insertReferencedEntities(PropertyAndValue propertyAndValue, AggregateChange aggregateChange,
-										  JdbcPropertyPath propertyPath, DbAction dependingOn) {
+			JdbcPropertyPath propertyPath, DbAction dependingOn) {
 
 		Insert<Object> insert;
 		if (propertyAndValue.property.isQualified()) {
@@ -116,7 +116,7 @@ public class JdbcEntityWriter extends JdbcEntityWriterSupport {
 				.flatMap( //
 						p -> referencedEntity(p, persistentEntity.getPropertyAccessor(o)) //
 								.map(e -> new PropertyAndValue(p, e)) //
-				);
+		);
 	}
 
 	private Stream<Object> referencedEntity(JdbcPersistentProperty p, PersistentPropertyAccessor propertyAccessor) {
@@ -147,7 +147,7 @@ public class JdbcEntityWriter extends JdbcEntityWriterSupport {
 	}
 
 	private Stream<Object> collectionPropertyAsStream(JdbcPersistentProperty p,
-													  PersistentPropertyAccessor propertyAccessor) {
+			PersistentPropertyAccessor propertyAccessor) {
 
 		Object property = propertyAccessor.getProperty(p);
 
@@ -160,7 +160,9 @@ public class JdbcEntityWriter extends JdbcEntityWriterSupport {
 
 		Object property = propertyAccessor.getProperty(p);
 
-		if (property == null) return Stream.empty();
+		if (property == null) {
+			return Stream.empty();
+		}
 
 		// ugly hackery since Java streams don't have a zip method.
 		AtomicInteger index = new AtomicInteger();

--- a/src/test/java/org/springframework/data/jdbc/core/conversion/JdbcEntityWriterUnitTests.java
+++ b/src/test/java/org/springframework/data/jdbc/core/conversion/JdbcEntityWriterUnitTests.java
@@ -203,6 +203,45 @@ public class JdbcEntityWriterUnitTests {
 		);
 	}
 
+	@Test // DATAJDBC-183
+	public void newEntityWithFullMapResultsInAdditionalInsertPerElement() {
+
+		MapContainer entity = new MapContainer(null);
+		entity.elements.put("1", new Element(null));
+		entity.elements.put("2", new Element(null));
+		entity.elements.put("3", new Element(null));
+		entity.elements.put("4", new Element(null));
+		entity.elements.put("5", new Element(null));
+		entity.elements.put("6", new Element(null));
+		entity.elements.put("7", new Element(null));
+		entity.elements.put("8", new Element(null));
+		entity.elements.put("9", new Element(null));
+		entity.elements.put("0", new Element(null));
+		entity.elements.put("a", new Element(null));
+		entity.elements.put("b", new Element(null));
+
+		AggregateChange<MapContainer> aggregateChange = new AggregateChange(Kind.SAVE, MapContainer.class, entity);
+		converter.write(entity, aggregateChange);
+
+		assertThat(aggregateChange.getActions())
+				.extracting(DbAction::getClass, DbAction::getEntityType, this::getMapKey, this::extractPath) //
+				.containsExactlyInAnyOrder( //
+						tuple(Insert.class, MapContainer.class, null, ""), //
+						tuple(Insert.class, Element.class, "1", "elements"), //
+						tuple(Insert.class, Element.class, "2", "elements"), //
+						tuple(Insert.class, Element.class, "3", "elements"), //
+						tuple(Insert.class, Element.class, "4", "elements"), //
+						tuple(Insert.class, Element.class, "5", "elements"), //
+						tuple(Insert.class, Element.class, "6", "elements"), //
+						tuple(Insert.class, Element.class, "7", "elements"), //
+						tuple(Insert.class, Element.class, "8", "elements"), //
+						tuple(Insert.class, Element.class, "9", "elements"), //
+						tuple(Insert.class, Element.class, "0", "elements"), //
+						tuple(Insert.class, Element.class, "a", "elements"), //
+						tuple(Insert.class, Element.class, "b", "elements") //
+				);
+	}
+
 	@Test // DATAJDBC-130
 	public void newEntityWithEmptyListResultsInSingleInsert() {
 

--- a/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithListsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithListsIntegrationTests.java
@@ -132,8 +132,6 @@ public class JdbcRepositoryWithListsIntegrationTests {
 
 		Iterable<DummyEntity> reloaded = repository.findAll();
 
-		reloaded.forEach(de -> System.out.println("id " + de.id + " content " + de.content.iterator().next().content));
-
 		assertThat(reloaded) //
 				.extracting(e -> e.id, e -> e.content.size()) //
 				.containsExactly(tuple(entity.id, entity.content.size()));

--- a/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithMapsIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryWithMapsIntegrationTests.java
@@ -127,8 +127,6 @@ public class JdbcRepositoryWithMapsIntegrationTests {
 
 		Iterable<DummyEntity> reloaded = repository.findAll();
 
-		reloaded.forEach(de -> System.out.println("id " + de.id + " content " + de.content.values().iterator().next().content));
-
 		assertThat(reloaded) //
 				.extracting(e -> e.id, e -> e.content.size()) //
 				.containsExactly(tuple(entity.id, entity.content.size()));


### PR DESCRIPTION
Instead of using Map.Entry we now use a dedicated class to hold key and value of a map entry.
This avoids side effects from the implementation of Map.Entry.

Replaced call to saveReferencedEntities with insertReferencedEntities which is simpler but equivalent since referenced entities always get only inserted, never updated.

Removed superfluous methods resulting from that change.