### PR TITLE
DATAJDBC-186 - Removed requirement for id properties.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.springframework.data</groupId>
     <artifactId>spring-data-jdbc</artifactId>
-    <version>1.0.0.BUILD-SNAPSHOT</version>
+    <version>1.0.0.DATAJDBC-186-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>

--- a/src/main/java/org/springframework/data/jdbc/core/EntityRowMapper.java
+++ b/src/main/java/org/springframework/data/jdbc/core/EntityRowMapper.java
@@ -31,6 +31,8 @@ import org.springframework.data.mapping.PreferredConstructor.Parameter;
 import org.springframework.data.mapping.model.ConvertingPropertyAccessor;
 import org.springframework.data.mapping.model.ParameterValueProvider;
 import org.springframework.jdbc.core.RowMapper;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -61,7 +63,7 @@ public class EntityRowMapper<T> implements RowMapper<T> {
 		this.context = context;
 		this.accessStrategy = accessStrategy;
 
-		idProperty = entity.getRequiredIdProperty();
+		idProperty = entity.getIdProperty();
 	}
 
 	/*
@@ -76,7 +78,7 @@ public class EntityRowMapper<T> implements RowMapper<T> {
 		ConvertingPropertyAccessor propertyAccessor = new ConvertingPropertyAccessor(entity.getPropertyAccessor(result),
 				conversions);
 
-		Object id = readFrom(resultSet, idProperty, "");
+		Object id = idProperty == null ? null : readFrom(resultSet, idProperty, "");
 
 		for (JdbcPersistentProperty property : entity) {
 

--- a/src/main/java/org/springframework/data/jdbc/core/EntityRowMapper.java
+++ b/src/main/java/org/springframework/data/jdbc/core/EntityRowMapper.java
@@ -100,6 +100,16 @@ public class EntityRowMapper<T> implements RowMapper<T> {
 		return instantiator.createInstance(entity, new ResultSetParameterValueProvider(rs, entity, conversions, ""));
 	}
 
+
+	/**
+	 * Read a single value or a complete Entity from the {@link ResultSet} passed as an argument.
+	 *
+	 * @param resultSet the {@link ResultSet} to extract the value from. Must not be {@code null}.
+	 * @param property the {@link JdbcPersistentProperty} for which the value is intended. Must not be {@code null}.
+	 * @param prefix to be used for all column names accessed by this method. Must not be {@code null}.
+	 *
+	 * @return the value read from the {@link ResultSet}. May be {@code null}.
+	 */
 	private Object readFrom(ResultSet resultSet, JdbcPersistentProperty property, String prefix) {
 
 		try {
@@ -109,6 +119,7 @@ public class EntityRowMapper<T> implements RowMapper<T> {
 			}
 
 			return resultSet.getObject(prefix + property.getColumnName());
+
 		} catch (SQLException o_O) {
 			throw new MappingException(String.format("Could not read property %s from result set!", property), o_O);
 		}

--- a/src/main/java/org/springframework/data/jdbc/core/SqlGenerator.java
+++ b/src/main/java/org/springframework/data/jdbc/core/SqlGenerator.java
@@ -27,6 +27,7 @@ import org.springframework.util.Assert;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -121,8 +122,8 @@ class SqlGenerator {
 		return findOneSql.get();
 	}
 
-	String getInsert(boolean excludeId, Set<String> additionalColumns) {
-		return createInsertSql(excludeId, additionalColumns);
+	String getInsert(Set<String> additionalColumns) {
+		return createInsertSql(additionalColumns);
 	}
 
 	String getUpdate() {
@@ -237,11 +238,11 @@ class SqlGenerator {
 		return String.format("select count(*) from %s", entity.getTableName());
 	}
 
-	private String createInsertSql(boolean excludeId, Set<String> additionalColumns) {
+	private String createInsertSql(Set<String> additionalColumns) {
 
 		String insertTemplate = "insert into %s (%s) values (%s)";
 
-		List<String> columnNamesForInsert = new ArrayList<>(excludeId ? nonIdColumnNames : columnNames);
+		LinkedHashSet<String> columnNamesForInsert = new LinkedHashSet<>(nonIdColumnNames);
 		columnNamesForInsert.addAll(additionalColumns);
 
 		String tableColumns = String.join(", ", columnNamesForInsert);

--- a/src/test/java/org/springframework/data/jdbc/core/DefaultDataAccessStrategyUnitTests.java
+++ b/src/test/java/org/springframework/data/jdbc/core/DefaultDataAccessStrategyUnitTests.java
@@ -42,7 +42,7 @@ public class DefaultDataAccessStrategyUnitTests {
 	NamedParameterJdbcOperations jdbcOperations = mock(NamedParameterJdbcOperations.class);
 	JdbcMappingContext context = new JdbcMappingContext(new DefaultNamingStrategy(), jdbcOperations, __ -> {});
 	HashMap<String, Object> additionalParameters = new HashMap<>();
-	ArgumentCaptor<SqlParameterSource> captor = ArgumentCaptor.forClass(SqlParameterSource.class);
+	ArgumentCaptor<SqlParameterSource> paramSourceCaptor = ArgumentCaptor.forClass(SqlParameterSource.class);
 
 	DefaultDataAccessStrategy accessStrategy = new DefaultDataAccessStrategy( //
 			new SqlGeneratorSource(context), //
@@ -57,21 +57,25 @@ public class DefaultDataAccessStrategyUnitTests {
 
 		accessStrategy.insert(new DummyEntity(ORIGINAL_ID), DummyEntity.class, additionalParameters);
 
-		verify(jdbcOperations).update(eq("insert into DummyEntity (id) values (:id)"), captor.capture(),
+		verify(jdbcOperations).update(eq("insert into DummyEntity (id) values (:id)"), paramSourceCaptor.capture(),
 				any(KeyHolder.class));
-		assertThat(captor.getValue().getValue("id")).isEqualTo(ID_FROM_ADDITIONAL_VALUES);
 	}
 
 	@Test // DATAJDBC-146
 	public void additionalParametersGetAddedToStatement() {
 
+		ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+
 		additionalParameters.put("reference", ID_FROM_ADDITIONAL_VALUES);
 
 		accessStrategy.insert(new DummyEntity(ORIGINAL_ID), DummyEntity.class, additionalParameters);
 
-		verify(jdbcOperations).update(eq("insert into DummyEntity (id, reference) values (:id, :reference)"),
-				captor.capture(), any(KeyHolder.class));
-		assertThat(captor.getValue().getValue("id")).isEqualTo(ORIGINAL_ID);
+		verify(jdbcOperations).update(sqlCaptor.capture(), paramSourceCaptor.capture(), any(KeyHolder.class));
+
+		assertThat(sqlCaptor.getValue()) //
+				.containsSequence("insert into DummyEntity (", "id", ") values (", ":id", ")") //
+				.containsSequence("insert into DummyEntity (", "reference", ") values (", ":reference", ")");
+		assertThat(paramSourceCaptor.getValue().getValue("id")).isEqualTo(ORIGINAL_ID);
 	}
 
 	@RequiredArgsConstructor

--- a/src/test/java/org/springframework/data/jdbc/core/DefaultDataAccessStrategyUnitTests.java
+++ b/src/test/java/org/springframework/data/jdbc/core/DefaultDataAccessStrategyUnitTests.java
@@ -32,6 +32,8 @@ import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.jdbc.support.KeyHolder;
 
 /**
+ * Unit tests for {@link DefaultDataAccessStrategy}.
+ *
  * @author Jens Schauder
  */
 public class DefaultDataAccessStrategyUnitTests {


### PR DESCRIPTION
It is now ok for an entity to be “new” after saving.
We now only check that an entity is not new when the id is provided by the database.
If in such a case the entity is still “new” after saving it basically means obtaining the id from JDBC and setting it in the entity failed.  

Removed need for entities in maps to have an id.

Together these changes simplify the requirements for Map values, which now can be value objects.