### PR TITLE
DATAJDBC-155 - Simplified construction of JdbcRepositoryFactory.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.springframework.data</groupId>
     <artifactId>spring-data-jdbc</artifactId>
-    <version>1.0.0.BUILD-SNAPSHOT</version>
+    <version>1.0.0.DATAJDBC-155-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>

--- a/src/main/java/org/springframework/data/jdbc/core/DefaultDataAccessStrategy.java
+++ b/src/main/java/org/springframework/data/jdbc/core/DefaultDataAccessStrategy.java
@@ -56,11 +56,11 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 	private final JdbcMappingContext context;
 	private final DataAccessStrategy accessStrategy;
 
-	public DefaultDataAccessStrategy(SqlGeneratorSource sqlGeneratorSource, NamedParameterJdbcOperations operations,
-			JdbcMappingContext context, DataAccessStrategy accessStrategy) {
+	public DefaultDataAccessStrategy(SqlGeneratorSource sqlGeneratorSource, JdbcMappingContext context,
+			DataAccessStrategy accessStrategy) {
 
 		this.sqlGeneratorSource = sqlGeneratorSource;
-		this.operations = operations;
+		this.operations = context.getTemplate();
 		this.context = context;
 		this.accessStrategy = accessStrategy;
 	}
@@ -69,11 +69,10 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 	 * Creates a {@link DefaultDataAccessStrategy} which references it self for resolution of recursive data accesses.
 	 * Only suitable if this is the only access strategy in use.
 	 */
-	public DefaultDataAccessStrategy(SqlGeneratorSource sqlGeneratorSource, NamedParameterJdbcOperations operations,
-			JdbcMappingContext context) {
+	public DefaultDataAccessStrategy(SqlGeneratorSource sqlGeneratorSource, JdbcMappingContext context) {
 
 		this.sqlGeneratorSource = sqlGeneratorSource;
-		this.operations = operations;
+		this.operations = context.getTemplate();
 		this.context = context;
 		this.accessStrategy = this;
 	}

--- a/src/main/java/org/springframework/data/jdbc/repository/config/JdbcConfiguration.java
+++ b/src/main/java/org/springframework/data/jdbc/repository/config/JdbcConfiguration.java
@@ -22,18 +22,20 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.jdbc.mapping.model.ConversionCustomizer;
 import org.springframework.data.jdbc.mapping.model.JdbcMappingContext;
 import org.springframework.data.jdbc.mapping.model.NamingStrategy;
+import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 
 /**
  * Beans that must be registered for Spring Data JDBC to work.
  *
  * @author Greg Turnquist
+ * @author Jens Schauder
  */
 @Configuration
 public class JdbcConfiguration {
 
 	@Bean
-	JdbcMappingContext jdbcMappingContext(NamedParameterJdbcTemplate template, Optional<NamingStrategy> namingStrategy,
+	JdbcMappingContext jdbcMappingContext(NamedParameterJdbcOperations template, Optional<NamingStrategy> namingStrategy,
 			Optional<ConversionCustomizer> conversionCustomizer) {
 
 		return new JdbcMappingContext(namingStrategy.orElse(NamingStrategy.INSTANCE), template,

--- a/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactory.java
@@ -30,12 +30,14 @@ import org.springframework.data.repository.core.RepositoryMetadata;
 import org.springframework.data.repository.core.support.RepositoryFactorySupport;
 import org.springframework.data.repository.query.EvaluationContextProvider;
 import org.springframework.data.repository.query.QueryLookupStrategy;
+import org.springframework.util.Assert;
 
 /**
  * Creates repository implementation based on JDBC.
  *
  * @author Jens Schauder
  * @author Greg Turnquist
+ * @author Christoph Strobl
  * @since 2.0
  */
 public class JdbcRepositoryFactory extends RepositoryFactorySupport {
@@ -89,7 +91,12 @@ public class JdbcRepositoryFactory extends RepositoryFactorySupport {
 		return Optional.of(new JdbcQueryLookupStrategy(evaluationContextProvider, context, accessStrategy, rowMapperMap));
 	}
 
+	/**
+	 * @param rowMapperMap must not be {@literal null} consider {@link RowMapperMap#EMPTY} instead.
+	 */
 	public void setRowMapperMap(RowMapperMap rowMapperMap) {
+
+		Assert.notNull(rowMapperMap, "RowMapperMap must not be null!");
 		this.rowMapperMap = rowMapperMap;
 	}
 }

--- a/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactoryBean.java
@@ -21,6 +21,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
 import org.springframework.data.jdbc.core.DataAccessStrategy;
+import org.springframework.data.jdbc.core.DefaultDataAccessStrategy;
+import org.springframework.data.jdbc.core.SqlGeneratorSource;
 import org.springframework.data.jdbc.mapping.model.JdbcMappingContext;
 import org.springframework.data.jdbc.repository.RowMapperMap;
 import org.springframework.data.repository.Repository;
@@ -80,7 +82,7 @@ public class JdbcRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extend
 		this.mappingContext = mappingContext;
 	}
 
-	@Autowired
+	@Autowired(required = false)
 	public void setDataAccessStrategy(DataAccessStrategy dataAccessStrategy) {
 		this.dataAccessStrategy = dataAccessStrategy;
 	}
@@ -93,8 +95,15 @@ public class JdbcRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extend
 	@Override
 	public void afterPropertiesSet() {
 
-		Assert.notNull(this.dataAccessStrategy, "DataAccessStrategy must not be null!");
 		Assert.notNull(this.mappingContext, "MappingContext must not be null!");
+
+		if (dataAccessStrategy == null) {
+
+			dataAccessStrategy = new DefaultDataAccessStrategy( //
+					new SqlGeneratorSource(mappingContext), //
+					mappingContext);
+		}
+
 		super.afterPropertiesSet();
 	}
 }

--- a/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactoryBean.java
@@ -36,6 +36,7 @@ import org.springframework.util.Assert;
  *
  * @author Jens Schauder
  * @author Greg Turnquist
+ * @author Christoph Strobl
  * @since 2.0
  */
 public class JdbcRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extends Serializable> //
@@ -67,10 +68,7 @@ public class JdbcRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extend
 
 		JdbcRepositoryFactory jdbcRepositoryFactory = new JdbcRepositoryFactory(publisher, mappingContext,
 				dataAccessStrategy);
-
-		if (rowMapperMap != null) {
-			jdbcRepositoryFactory.setRowMapperMap(rowMapperMap);
-		}
+		jdbcRepositoryFactory.setRowMapperMap(rowMapperMap);
 
 		return jdbcRepositoryFactory;
 	}
@@ -82,11 +80,18 @@ public class JdbcRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extend
 		this.mappingContext = mappingContext;
 	}
 
+	/**
+	 * @param dataAccessStrategy can be {@literal null}.
+	 */
 	@Autowired(required = false)
 	public void setDataAccessStrategy(DataAccessStrategy dataAccessStrategy) {
 		this.dataAccessStrategy = dataAccessStrategy;
 	}
 
+	/**
+	 * @param rowMapperMap can be {@literal null}. {@link #afterPropertiesSet()} defaults to {@link RowMapperMap#EMPTY} if
+	 *          {@literal null}.
+	 */
 	@Autowired(required = false)
 	public void setRowMapperMap(RowMapperMap rowMapperMap) {
 		this.rowMapperMap = rowMapperMap;
@@ -95,13 +100,17 @@ public class JdbcRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extend
 	@Override
 	public void afterPropertiesSet() {
 
-		Assert.notNull(this.mappingContext, "MappingContext must not be null!");
+		Assert.state(this.mappingContext != null, "MappingContext is required and must not be null!");
 
 		if (dataAccessStrategy == null) {
 
 			dataAccessStrategy = new DefaultDataAccessStrategy( //
 					new SqlGeneratorSource(mappingContext), //
 					mappingContext);
+		}
+
+		if (rowMapperMap == null) {
+			rowMapperMap = RowMapperMap.EMPTY;
 		}
 
 		super.afterPropertiesSet();

--- a/src/test/java/org/springframework/data/jdbc/core/DefaultDataAccessStrategyUnitTests.java
+++ b/src/test/java/org/springframework/data/jdbc/core/DefaultDataAccessStrategyUnitTests.java
@@ -48,7 +48,6 @@ public class DefaultDataAccessStrategyUnitTests {
 
 	DefaultDataAccessStrategy accessStrategy = new DefaultDataAccessStrategy( //
 			new SqlGeneratorSource(context), //
-			jdbcOperations, //
 			context //
 	);
 

--- a/src/test/java/org/springframework/data/jdbc/mybatis/MyBatisHsqlIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jdbc/mybatis/MyBatisHsqlIntegrationTests.java
@@ -15,7 +15,7 @@
  */
 package org.springframework.data.jdbc.mybatis;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 import junit.framework.AssertionFailedError;
 
@@ -30,6 +30,8 @@ import org.mybatis.spring.SqlSessionTemplate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.jdbc.core.DataAccessStrategy;
+import org.springframework.data.jdbc.mapping.model.JdbcMappingContext;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.CrudRepository;
@@ -38,8 +40,6 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
 import org.springframework.transaction.annotation.Transactional;
-
-import javax.net.ssl.SSLSocketFactory;
 
 /**
  * Tests the integration with Mybatis.
@@ -83,8 +83,8 @@ public class MyBatisHsqlIntegrationTests {
 		}
 
 		@Bean
-		MyBatisDataAccessStrategy dataAccessStrategy(SqlSession sqlSession) {
-			return new MyBatisDataAccessStrategy(sqlSession);
+		DataAccessStrategy dataAccessStrategy(JdbcMappingContext context, SqlSession sqlSession) {
+			return MyBatisDataAccessStrategy.createCombinedAccessStrategy(context, sqlSession);
 		}
 	}
 

--- a/src/test/java/org/springframework/data/jdbc/repository/SimpleJdbcRepositoryEventsUnitTests.java
+++ b/src/test/java/org/springframework/data/jdbc/repository/SimpleJdbcRepositoryEventsUnitTests.java
@@ -46,13 +46,12 @@ public class SimpleJdbcRepositoryEventsUnitTests {
 	@Before
 	public void before() {
 
-		final JdbcMappingContext context = new JdbcMappingContext(mock(NamedParameterJdbcOperations.class));
+		final JdbcMappingContext context = new JdbcMappingContext(createIdGeneratingOperations());
 		JdbcRepositoryFactory factory = new JdbcRepositoryFactory( //
 				publisher, //
 				context, //
 				new DefaultDataAccessStrategy( //
 						new SqlGeneratorSource(context), //
-						createIdGeneratingOperations(), //
 						context //
 				) //
 		);


### PR DESCRIPTION
Made the DefaultDataAccessStrategy actually the default for JdbcRepositoryFactoryBean.
Therefore the injection of a strategy is optional.

Simplified constructors of DefaultDataAccessStrategy.
Created factory method to construct a correct DataAccessStrategy for use with MyBatis.

Did some untangling in the test application context configurations.