### PR TITLE
DATAJDBC-198 - fix running integration-tests against specific db

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -339,7 +339,7 @@ This will execute unit tests and integration tests using an in-memory database.
 
 === Running tests with a real database
 
-To run the integration tests against a specific database you need to have the database running on your local machine and then execute.
+In order to run the integration tests against a specific database you need to have a local Docker installation available, and then execute.
 
 [source]
 ----

--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,12 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework</groupId>
+			<artifactId>spring-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>org.mybatis</groupId>
 			<artifactId>mybatis-spring</artifactId>
 			<version>${mybatis-spring.version}</version>

--- a/src/test/java/org/springframework/data/jdbc/mybatis/MyBatisCustomizingNamespaceHsqlIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jdbc/mybatis/MyBatisCustomizingNamespaceHsqlIntegrationTests.java
@@ -37,6 +37,7 @@ import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
@@ -49,6 +50,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Jens Schauder
  */
 @ContextConfiguration
+@ActiveProfiles("hsql")
 @Transactional
 public class MyBatisCustomizingNamespaceHsqlIntegrationTests {
 

--- a/src/test/java/org/springframework/data/jdbc/mybatis/MyBatisHsqlIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jdbc/mybatis/MyBatisHsqlIntegrationTests.java
@@ -36,6 +36,7 @@ import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
@@ -48,6 +49,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Greg Turnquist
  */
 @ContextConfiguration
+@ActiveProfiles("hsql")
 @Transactional
 public class MyBatisHsqlIntegrationTests {
 

--- a/src/test/java/org/springframework/data/jdbc/repository/query/QueryAnnotationHsqlIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jdbc/repository/query/QueryAnnotationHsqlIntegrationTests.java
@@ -36,6 +36,7 @@ import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
@@ -48,6 +49,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Kazuki Shimizu
  */
 @ContextConfiguration
+@ActiveProfiles("hsql")
 @Transactional
 public class QueryAnnotationHsqlIntegrationTests {
 


### PR DESCRIPTION
running "mvn test -Dspring.profiles.active=<databasetype>" causes errors
because "*HsqlIntegrationTests" tests are executed as well