### PR TITLE
DATAJDBC-209 - Improve assertion on The QueryAnnotationHsqlIntegrationTests#executeCustomQueryWithReturnTypeIsDate

### DIFF
--- a/src/test/java/org/springframework/data/jdbc/repository/query/QueryAnnotationHsqlIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jdbc/repository/query/QueryAnnotationHsqlIntegrationTests.java
@@ -17,6 +17,7 @@ package org.springframework.data.jdbc.repository.query;
 
 import static org.assertj.core.api.Assertions.*;
 
+import java.sql.Timestamp;
 import java.time.LocalDateTime;
 import java.util.Date;
 import java.util.List;
@@ -195,7 +196,7 @@ public class QueryAnnotationHsqlIntegrationTests {
 	@Test // DATAJDBC-175
 	public void executeCustomQueryWithReturnTypeIsDate() {
 
-		Date now = new Date();
+		Date now = new Timestamp(System.currentTimeMillis());
 		assertThat(repository.nowWithDate()).isAfterOrEqualsTo(now);
 
 	}


### PR DESCRIPTION
I've fixed the [DATAJDBC-209](https://jira.spring.io/browse/DATAJDBC-209).
