### PR TITLE
DATAJDBC-102 - Determine the EntityInstantiator to be used dynamically.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.springframework.data</groupId>
     <artifactId>spring-data-jdbc</artifactId>
-    <version>1.0.0.BUILD-SNAPSHOT</version>
+    <version>1.0.0.DATAJDBC-102-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>

--- a/src/main/java/org/springframework/data/jdbc/core/DefaultDataAccessStrategy.java
+++ b/src/main/java/org/springframework/data/jdbc/core/DefaultDataAccessStrategy.java
@@ -27,6 +27,7 @@ import java.util.stream.StreamSupport;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.dao.NonTransientDataAccessException;
+import org.springframework.data.convert.EntityInstantiators;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.jdbc.core.mapping.JdbcPersistentEntity;
 import org.springframework.data.jdbc.core.mapping.JdbcPersistentProperty;
@@ -58,6 +59,7 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 	private final @NonNull SqlGeneratorSource sqlGeneratorSource;
 	private final @NonNull JdbcMappingContext context;
 	private final @NonNull NamedParameterJdbcOperations operations;
+	private final @NonNull EntityInstantiators instantiators;
 	private final @NonNull DataAccessStrategy accessStrategy;
 
 	/**
@@ -65,11 +67,12 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 	 * Only suitable if this is the only access strategy in use.
 	 */
 	public DefaultDataAccessStrategy(SqlGeneratorSource sqlGeneratorSource, JdbcMappingContext context,
-			NamedParameterJdbcOperations operations) {
+			NamedParameterJdbcOperations operations, EntityInstantiators instantiators) {
 
 		this.sqlGeneratorSource = sqlGeneratorSource;
 		this.operations = operations;
 		this.context = context;
+		this.instantiators = instantiators;
 		this.accessStrategy = this;
 	}
 
@@ -321,7 +324,7 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 	}
 
 	public <T> EntityRowMapper<T> getEntityRowMapper(Class<T> domainType) {
-		return new EntityRowMapper<>(getRequiredPersistentEntity(domainType), context, accessStrategy);
+		return new EntityRowMapper<>(getRequiredPersistentEntity(domainType), context, instantiators, accessStrategy);
 	}
 
 	private RowMapper getMapEntityRowMapper(JdbcPersistentProperty property) {

--- a/src/main/java/org/springframework/data/jdbc/core/EntityRowMapper.java
+++ b/src/main/java/org/springframework/data/jdbc/core/EntityRowMapper.java
@@ -24,8 +24,7 @@ import java.util.Map;
 
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.converter.Converter;
-import org.springframework.data.convert.ClassGeneratingEntityInstantiator;
-import org.springframework.data.convert.EntityInstantiator;
+import org.springframework.data.convert.EntityInstantiators;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.jdbc.core.mapping.JdbcPersistentEntity;
 import org.springframework.data.jdbc.core.mapping.JdbcPersistentProperty;
@@ -49,7 +48,7 @@ public class EntityRowMapper<T> implements RowMapper<T> {
 	private static final Converter<Iterable<?>, Map<?, ?>> ITERABLE_OF_ENTRY_TO_MAP_CONVERTER = new IterableOfEntryToMapConverter();
 
 	private final JdbcPersistentEntity<T> entity;
-	private final EntityInstantiator instantiator = new ClassGeneratingEntityInstantiator();
+
 	private final ConversionService conversions;
 	private final JdbcMappingContext context;
 	private final DataAccessStrategy accessStrategy;
@@ -97,7 +96,9 @@ public class EntityRowMapper<T> implements RowMapper<T> {
 	}
 
 	private T createInstance(ResultSet rs) {
-		return instantiator.createInstance(entity, new ResultSetParameterValueProvider(rs, entity, conversions, ""));
+
+		return context.getInstantiatorFor(entity) //
+				.createInstance(entity, new ResultSetParameterValueProvider(rs, entity, conversions, ""));
 	}
 
 	/**
@@ -135,8 +136,8 @@ public class EntityRowMapper<T> implements RowMapper<T> {
 			return null;
 		}
 
-		S instance = instantiator.createInstance(entity,
-				new ResultSetParameterValueProvider(rs, entity, conversions, prefix));
+		S instance = context.getInstantiatorFor(entity) //
+				.createInstance(entity, new ResultSetParameterValueProvider(rs, entity, conversions, prefix));
 
 		PersistentPropertyAccessor accessor = entity.getPropertyAccessor(instance);
 		ConvertingPropertyAccessor propertyAccessor = new ConvertingPropertyAccessor(accessor, conversions);

--- a/src/main/java/org/springframework/data/jdbc/core/EntityRowMapper.java
+++ b/src/main/java/org/springframework/data/jdbc/core/EntityRowMapper.java
@@ -53,13 +53,15 @@ public class EntityRowMapper<T> implements RowMapper<T> {
 	private final JdbcMappingContext context;
 	private final DataAccessStrategy accessStrategy;
 	private final JdbcPersistentProperty idProperty;
+	private final EntityInstantiators instantiators;
 
-	public EntityRowMapper(JdbcPersistentEntity<T> entity, JdbcMappingContext context,
+	public EntityRowMapper(JdbcPersistentEntity<T> entity, JdbcMappingContext context, EntityInstantiators instantiators,
 			DataAccessStrategy accessStrategy) {
 
 		this.entity = entity;
 		this.conversions = context.getConversions();
 		this.context = context;
+		this.instantiators = instantiators;
 		this.accessStrategy = accessStrategy;
 
 		idProperty = entity.getIdProperty();
@@ -97,7 +99,7 @@ public class EntityRowMapper<T> implements RowMapper<T> {
 
 	private T createInstance(ResultSet rs) {
 
-		return context.getInstantiatorFor(entity) //
+		return instantiators.getInstantiatorFor(entity) //
 				.createInstance(entity, new ResultSetParameterValueProvider(rs, entity, conversions, ""));
 	}
 
@@ -136,7 +138,7 @@ public class EntityRowMapper<T> implements RowMapper<T> {
 			return null;
 		}
 
-		S instance = context.getInstantiatorFor(entity) //
+		S instance = instantiators.getInstantiatorFor(entity) //
 				.createInstance(entity, new ResultSetParameterValueProvider(rs, entity, conversions, prefix));
 
 		PersistentPropertyAccessor accessor = entity.getPropertyAccessor(instance);

--- a/src/main/java/org/springframework/data/jdbc/core/mapping/JdbcMappingContext.java
+++ b/src/main/java/org/springframework/data/jdbc/core/mapping/JdbcMappingContext.java
@@ -27,10 +27,14 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
+import lombok.Setter;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.convert.support.GenericConversionService;
+import org.springframework.data.convert.EntityInstantiator;
+import org.springframework.data.convert.EntityInstantiators;
 import org.springframework.data.convert.Jsr310Converters;
+import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PropertyPath;
 import org.springframework.data.mapping.context.AbstractMappingContext;
 import org.springframework.data.mapping.context.MappingContext;
@@ -59,6 +63,8 @@ public class JdbcMappingContext extends AbstractMappingContext<JdbcPersistentEnt
 	@Getter private final NamingStrategy namingStrategy;
 	@Getter private SimpleTypeHolder simpleTypeHolder;
 	private GenericConversionService conversions = getDefaultConversionService();
+	@Setter
+	private EntityInstantiators instantiators = new EntityInstantiators();
 
 	/**
 	 * Creates a new {@link JdbcMappingContext}.
@@ -141,6 +147,10 @@ public class JdbcMappingContext extends AbstractMappingContext<JdbcPersistentEnt
 
 	public ConversionService getConversions() {
 		return conversions;
+	}
+
+	public EntityInstantiator getInstantiatorFor(PersistentEntity<?, ?> entity) {
+		return instantiators.getInstantiatorFor(entity);
 	}
 
 	private static GenericConversionService getDefaultConversionService() {

--- a/src/main/java/org/springframework/data/jdbc/core/mapping/JdbcMappingContext.java
+++ b/src/main/java/org/springframework/data/jdbc/core/mapping/JdbcMappingContext.java
@@ -27,14 +27,10 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 
-import lombok.Setter;
 import org.springframework.core.convert.ConversionService;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.convert.support.GenericConversionService;
-import org.springframework.data.convert.EntityInstantiator;
-import org.springframework.data.convert.EntityInstantiators;
 import org.springframework.data.convert.Jsr310Converters;
-import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PropertyPath;
 import org.springframework.data.mapping.context.AbstractMappingContext;
 import org.springframework.data.mapping.context.MappingContext;
@@ -63,8 +59,6 @@ public class JdbcMappingContext extends AbstractMappingContext<JdbcPersistentEnt
 	@Getter private final NamingStrategy namingStrategy;
 	@Getter private SimpleTypeHolder simpleTypeHolder;
 	private GenericConversionService conversions = getDefaultConversionService();
-	@Setter
-	private EntityInstantiators instantiators = new EntityInstantiators();
 
 	/**
 	 * Creates a new {@link JdbcMappingContext}.
@@ -147,10 +141,6 @@ public class JdbcMappingContext extends AbstractMappingContext<JdbcPersistentEnt
 
 	public ConversionService getConversions() {
 		return conversions;
-	}
-
-	public EntityInstantiator getInstantiatorFor(PersistentEntity<?, ?> entity) {
-		return instantiators.getInstantiatorFor(entity);
 	}
 
 	private static GenericConversionService getDefaultConversionService() {

--- a/src/main/java/org/springframework/data/jdbc/mybatis/MyBatisDataAccessStrategy.java
+++ b/src/main/java/org/springframework/data/jdbc/mybatis/MyBatisDataAccessStrategy.java
@@ -22,6 +22,7 @@ import java.util.Map;
 
 import org.apache.ibatis.session.SqlSession;
 import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.data.convert.EntityInstantiators;
 import org.springframework.data.jdbc.core.CascadingDataAccessStrategy;
 import org.springframework.data.jdbc.core.DataAccessStrategy;
 import org.springframework.data.jdbc.core.DefaultDataAccessStrategy;
@@ -58,7 +59,8 @@ public class MyBatisDataAccessStrategy implements DataAccessStrategy {
 	 */
 	public static DataAccessStrategy createCombinedAccessStrategy(JdbcMappingContext context,
 			NamedParameterJdbcOperations operations, SqlSession sqlSession) {
-		return createCombinedAccessStrategy(context, operations, sqlSession, NamespaceStrategy.DEFAULT_INSTANCE);
+		return createCombinedAccessStrategy(context, new EntityInstantiators(), operations, sqlSession,
+				NamespaceStrategy.DEFAULT_INSTANCE);
 	}
 
 	/**
@@ -66,7 +68,8 @@ public class MyBatisDataAccessStrategy implements DataAccessStrategy {
 	 * uses a {@link DefaultDataAccessStrategy}
 	 */
 	public static DataAccessStrategy createCombinedAccessStrategy(JdbcMappingContext context,
-			NamedParameterJdbcOperations operations, SqlSession sqlSession, NamespaceStrategy namespaceStrategy) {
+			EntityInstantiators instantiators, NamedParameterJdbcOperations operations, SqlSession sqlSession,
+			NamespaceStrategy namespaceStrategy) {
 
 		// the DefaultDataAccessStrategy needs a reference to the returned DataAccessStrategy. This creates a dependency
 		// cycle. In order to create it, we need something that allows to defer closing the cycle until all the elements are
@@ -79,8 +82,13 @@ public class MyBatisDataAccessStrategy implements DataAccessStrategy {
 				asList(myBatisDataAccessStrategy, delegatingDataAccessStrategy));
 
 		SqlGeneratorSource sqlGeneratorSource = new SqlGeneratorSource(context);
-		DefaultDataAccessStrategy defaultDataAccessStrategy = new DefaultDataAccessStrategy(sqlGeneratorSource, context,
-				operations, cascadingDataAccessStrategy);
+		DefaultDataAccessStrategy defaultDataAccessStrategy = new DefaultDataAccessStrategy( //
+				sqlGeneratorSource, //
+				context, //
+				operations, //
+				instantiators, //
+				cascadingDataAccessStrategy //
+		);
 
 		delegatingDataAccessStrategy.setDelegate(defaultDataAccessStrategy);
 
@@ -93,8 +101,9 @@ public class MyBatisDataAccessStrategy implements DataAccessStrategy {
 	 * Use a {@link SqlSessionTemplate} for {@link SqlSession} or a similar implementation tying the session to the proper
 	 * transaction. Note that the resulting {@link DataAccessStrategy} only handles MyBatis. It does not include the
 	 * functionality of the {@link org.springframework.data.jdbc.core.DefaultDataAccessStrategy} which one normally still
-	 * wants. Use {@link #createCombinedAccessStrategy(JdbcMappingContext, SqlSession)} to create such a
-	 * {@link DataAccessStrategy}.
+	 * wants. Use
+	 * {@link #createCombinedAccessStrategy(JdbcMappingContext, EntityInstantiators, NamedParameterJdbcOperations, SqlSession, NamespaceStrategy)}
+	 * to create such a {@link DataAccessStrategy}.
 	 *
 	 * @param sqlSession Must be non {@literal null}.
 	 */

--- a/src/main/java/org/springframework/data/jdbc/repository/support/JdbcQueryLookupStrategy.java
+++ b/src/main/java/org/springframework/data/jdbc/repository/support/JdbcQueryLookupStrategy.java
@@ -18,6 +18,7 @@ package org.springframework.data.jdbc.repository.support;
 import java.lang.reflect.Method;
 
 import org.springframework.core.convert.ConversionService;
+import org.springframework.data.convert.EntityInstantiators;
 import org.springframework.data.jdbc.core.DataAccessStrategy;
 import org.springframework.data.jdbc.core.EntityRowMapper;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
@@ -43,27 +44,30 @@ import org.springframework.util.Assert;
 class JdbcQueryLookupStrategy implements QueryLookupStrategy {
 
 	private final JdbcMappingContext context;
+	private final EntityInstantiators instantiators;
 	private final DataAccessStrategy accessStrategy;
 	private final RowMapperMap rowMapperMap;
-	private final ConversionService conversionService;
 	private final NamedParameterJdbcOperations operations;
+
+	private final ConversionService conversionService;
 
 	/**
 	 * Creates a new {@link JdbcQueryLookupStrategy} for the given {@link JdbcMappingContext}, {@link DataAccessStrategy}
 	 * and {@link RowMapperMap}.
-	 * 
+	 *
 	 * @param context must not be {@literal null}.
 	 * @param accessStrategy must not be {@literal null}.
 	 * @param rowMapperMap must not be {@literal null}.
 	 */
-	JdbcQueryLookupStrategy(JdbcMappingContext context, DataAccessStrategy accessStrategy, RowMapperMap rowMapperMap,
-			NamedParameterJdbcOperations operations) {
+	JdbcQueryLookupStrategy(JdbcMappingContext context, EntityInstantiators instantiators,
+			DataAccessStrategy accessStrategy, RowMapperMap rowMapperMap, NamedParameterJdbcOperations operations) {
 
 		Assert.notNull(context, "JdbcMappingContext must not be null!");
 		Assert.notNull(accessStrategy, "DataAccessStrategy must not be null!");
 		Assert.notNull(rowMapperMap, "RowMapperMap must not be null!");
 
 		this.context = context;
+		this.instantiators = instantiators;
 		this.accessStrategy = accessStrategy;
 		this.rowMapperMap = rowMapperMap;
 		this.conversionService = context.getConversions();
@@ -104,6 +108,7 @@ class JdbcQueryLookupStrategy implements QueryLookupStrategy {
 				? new EntityRowMapper<>( //
 						context.getRequiredPersistentEntity(domainType), //
 						context, //
+						instantiators, //
 						accessStrategy) //
 				: typeMappedRowMapper;
 	}

--- a/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactory.java
@@ -18,6 +18,7 @@ package org.springframework.data.jdbc.repository.support;
 import java.util.Optional;
 
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.convert.EntityInstantiators;
 import org.springframework.data.jdbc.core.DataAccessStrategy;
 import org.springframework.data.jdbc.core.JdbcAggregateTemplate;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
@@ -49,6 +50,7 @@ public class JdbcRepositoryFactory extends RepositoryFactorySupport {
 	private final NamedParameterJdbcOperations operations;
 
 	private RowMapperMap rowMapperMap = RowMapperMap.EMPTY;
+	private EntityInstantiators instantiators = new EntityInstantiators();
 
 	/**
 	 * Creates a new {@link JdbcRepositoryFactory} for the given {@link DataAccessStrategy}, {@link JdbcMappingContext}
@@ -80,6 +82,18 @@ public class JdbcRepositoryFactory extends RepositoryFactorySupport {
 		Assert.notNull(rowMapperMap, "RowMapperMap must not be null!");
 
 		this.rowMapperMap = rowMapperMap;
+	}
+
+	/**
+	 * Set the {@link EntityInstantiators} used for instantiating entity instances.
+	 * 
+	 * @param instantiators Must not be {@code null}.
+	 */
+	public void setEntityInstantiators(EntityInstantiators instantiators) {
+
+		Assert.notNull(instantiators, "EntityInstantiators must not be null.");
+
+		this.instantiators = instantiators;
 	}
 
 	@SuppressWarnings("unchecked")
@@ -127,6 +141,6 @@ public class JdbcRepositoryFactory extends RepositoryFactorySupport {
 			throw new IllegalArgumentException(String.format("Unsupported query lookup strategy %s!", key));
 		}
 
-		return Optional.of(new JdbcQueryLookupStrategy(context, accessStrategy, rowMapperMap, operations));
+		return Optional.of(new JdbcQueryLookupStrategy(context, instantiators, accessStrategy, rowMapperMap, operations));
 	}
 }

--- a/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactoryBean.java
+++ b/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactoryBean.java
@@ -20,6 +20,7 @@ import java.io.Serializable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
+import org.springframework.data.convert.EntityInstantiators;
 import org.springframework.data.jdbc.core.DataAccessStrategy;
 import org.springframework.data.jdbc.core.DefaultDataAccessStrategy;
 import org.springframework.data.jdbc.core.SqlGeneratorSource;
@@ -49,6 +50,7 @@ public class JdbcRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extend
 	private DataAccessStrategy dataAccessStrategy;
 	private RowMapperMap rowMapperMap = RowMapperMap.EMPTY;
 	private NamedParameterJdbcOperations operations;
+	private EntityInstantiators instantiators = new EntityInstantiators();
 
 	/**
 	 * Creates a new {@link JdbcRepositoryFactoryBean} for the given repository interface.
@@ -115,6 +117,11 @@ public class JdbcRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extend
 		this.operations = operations;
 	}
 
+	@Autowired(required = false)
+	public void setInstantiators(EntityInstantiators instantiators) {
+		this.instantiators = instantiators;
+	}
+
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport#afterPropertiesSet()
@@ -127,11 +134,16 @@ public class JdbcRepositoryFactoryBean<T extends Repository<S, ID>, S, ID extend
 		if (dataAccessStrategy == null) {
 
 			SqlGeneratorSource sqlGeneratorSource = new SqlGeneratorSource(mappingContext);
-			this.dataAccessStrategy = new DefaultDataAccessStrategy(sqlGeneratorSource, mappingContext, operations);
+			this.dataAccessStrategy = new DefaultDataAccessStrategy(sqlGeneratorSource, mappingContext, operations,
+					instantiators);
 		}
 
 		if (rowMapperMap == null) {
 			this.rowMapperMap = RowMapperMap.EMPTY;
+		}
+
+		if (instantiators == null) {
+			this.instantiators = new EntityInstantiators();
 		}
 
 		super.afterPropertiesSet();

--- a/src/test/java/org/springframework/data/jdbc/core/DefaultDataAccessStrategyUnitTests.java
+++ b/src/test/java/org/springframework/data/jdbc/core/DefaultDataAccessStrategyUnitTests.java
@@ -16,7 +16,8 @@
 package org.springframework.data.jdbc.core;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import lombok.RequiredArgsConstructor;
@@ -26,8 +27,8 @@ import java.util.HashMap;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.convert.EntityInstantiators;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
-import org.springframework.data.jdbc.core.mapping.NamingStrategy;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.jdbc.support.KeyHolder;
@@ -47,8 +48,12 @@ public class DefaultDataAccessStrategyUnitTests {
 	HashMap<String, Object> additionalParameters = new HashMap<>();
 	ArgumentCaptor<SqlParameterSource> paramSourceCaptor = ArgumentCaptor.forClass(SqlParameterSource.class);
 
-	DefaultDataAccessStrategy accessStrategy = new DefaultDataAccessStrategy(new SqlGeneratorSource(context), context,
-			jdbcOperations);
+	DefaultDataAccessStrategy accessStrategy = new DefaultDataAccessStrategy( //
+			new SqlGeneratorSource(context), //
+			context, //
+			jdbcOperations, //
+			new EntityInstantiators() //
+	);
 
 	@Test // DATAJDBC-146
 	public void additionalParameterForIdDoesNotLeadToDuplicateParameters() {

--- a/src/test/java/org/springframework/data/jdbc/core/EntityRowMapperUnitTests.java
+++ b/src/test/java/org/springframework/data/jdbc/core/EntityRowMapperUnitTests.java
@@ -17,7 +17,8 @@ package org.springframework.data.jdbc.core;
 
 import static java.util.Arrays.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import lombok.RequiredArgsConstructor;
@@ -40,12 +41,12 @@ import org.mockito.stubbing.Answer;
 import org.springframework.core.convert.support.DefaultConversionService;
 import org.springframework.core.convert.support.GenericConversionService;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.convert.EntityInstantiators;
 import org.springframework.data.convert.Jsr310Converters;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.jdbc.core.mapping.JdbcPersistentEntity;
 import org.springframework.data.jdbc.core.mapping.JdbcPersistentProperty;
 import org.springframework.data.jdbc.core.mapping.NamingStrategy;
-import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
 import org.springframework.util.Assert;
 
 /**
@@ -199,8 +200,12 @@ public class EntityRowMapperUnitTests {
 		DefaultConversionService.addDefaultConverters(conversionService);
 		Jsr310Converters.getConvertersToRegister().forEach(conversionService::addConverter);
 
-		return new EntityRowMapper<>((JdbcPersistentEntity<T>) context.getRequiredPersistentEntity(type), context,
-				accessStrategy);
+		return new EntityRowMapper<>( //
+				(JdbcPersistentEntity<T>) context.getRequiredPersistentEntity(type), //
+				context, //
+				new EntityInstantiators(), //
+				accessStrategy //
+		);
 	}
 
 	private static ResultSet mockResultSet(List<String> columns, Object... values) {
@@ -212,7 +217,7 @@ public class EntityRowMapperUnitTests {
 								"Number of values [%d] must be a multiple of the number of columns [%d]", //
 								values.length, //
 								columns.size() //
-						) //
+				) //
 		);
 
 		List<Map<String, Object>> result = convertValues(columns, values);

--- a/src/test/java/org/springframework/data/jdbc/repository/SimpleJdbcRepositoryEventsUnitTests.java
+++ b/src/test/java/org/springframework/data/jdbc/repository/SimpleJdbcRepositoryEventsUnitTests.java
@@ -17,7 +17,9 @@ package org.springframework.data.jdbc.repository;
 
 import static java.util.Arrays.*;
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import junit.framework.AssertionFailedError;
@@ -34,6 +36,7 @@ import org.junit.Test;
 import org.mockito.stubbing.Answer;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.convert.EntityInstantiators;
 import org.springframework.data.jdbc.core.DefaultDataAccessStrategy;
 import org.springframework.data.jdbc.core.SqlGeneratorSource;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
@@ -73,7 +76,8 @@ public class SimpleJdbcRepositoryEventsUnitTests {
 		NamedParameterJdbcOperations operations = createIdGeneratingOperations();
 		SqlGeneratorSource generatorSource = new SqlGeneratorSource(context);
 
-		this.dataAccessStrategy = spy(new DefaultDataAccessStrategy(generatorSource, context, operations));
+		this.dataAccessStrategy = spy(
+				new DefaultDataAccessStrategy(generatorSource, context, operations, new EntityInstantiators()));
 
 		JdbcRepositoryFactory factory = new JdbcRepositoryFactory(dataAccessStrategy, context, publisher, operations);
 
@@ -93,7 +97,7 @@ public class SimpleJdbcRepositoryEventsUnitTests {
 				.containsExactly( //
 						BeforeSaveEvent.class, //
 						AfterSaveEvent.class //
-				);
+		);
 	}
 
 	@Test // DATAJDBC-99
@@ -112,7 +116,7 @@ public class SimpleJdbcRepositoryEventsUnitTests {
 						AfterSaveEvent.class, //
 						BeforeSaveEvent.class, //
 						AfterSaveEvent.class //
-				);
+		);
 	}
 
 	@Test // DATAJDBC-99
@@ -143,7 +147,7 @@ public class SimpleJdbcRepositoryEventsUnitTests {
 				.containsExactly( //
 						BeforeDeleteEvent.class, //
 						AfterDeleteEvent.class //
-				);
+		);
 	}
 
 	@Test // DATAJDBC-197
@@ -162,7 +166,7 @@ public class SimpleJdbcRepositoryEventsUnitTests {
 				.containsExactly( //
 						AfterLoadEvent.class, //
 						AfterLoadEvent.class //
-				);
+		);
 	}
 
 	@Test // DATAJDBC-197
@@ -181,7 +185,7 @@ public class SimpleJdbcRepositoryEventsUnitTests {
 				.containsExactly( //
 						AfterLoadEvent.class, //
 						AfterLoadEvent.class //
-				);
+		);
 	}
 
 	@Test // DATAJDBC-197
@@ -198,7 +202,7 @@ public class SimpleJdbcRepositoryEventsUnitTests {
 				.extracting(e -> (Class) e.getClass()) //
 				.containsExactly( //
 						AfterLoadEvent.class //
-				);
+		);
 	}
 
 	private static NamedParameterJdbcOperations createIdGeneratingOperations() {

--- a/src/test/java/org/springframework/data/jdbc/repository/config/EnableJdbcAuditingHsqlIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jdbc/repository/config/EnableJdbcAuditingHsqlIntegrationTests.java
@@ -32,6 +32,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.Id;
@@ -41,6 +42,7 @@ import org.springframework.data.auditing.DateTimeProvider;
 import org.springframework.data.domain.AuditorAware;
 import org.springframework.data.jdbc.core.mapping.NamingStrategy;
 import org.springframework.data.repository.CrudRepository;
+import org.springframework.test.context.ActiveProfiles;
 
 /**
  * Tests the {@link EnableJdbcAuditing} annotation.
@@ -48,6 +50,7 @@ import org.springframework.data.repository.CrudRepository;
  * @author Kazuki Shimizu
  * @author Jens Schauder
  */
+@ActiveProfiles("hsql")
 public class EnableJdbcAuditingHsqlIntegrationTests {
 
 	SoftAssertions softly = new SoftAssertions();

--- a/src/test/java/org/springframework/data/jdbc/repository/support/JdbcQueryLookupStrategyUnitTests.java
+++ b/src/test/java/org/springframework/data/jdbc/repository/support/JdbcQueryLookupStrategyUnitTests.java
@@ -15,7 +15,9 @@
  */
 package org.springframework.data.jdbc.repository.support;
 
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 import java.lang.reflect.Method;
@@ -23,6 +25,7 @@ import java.text.NumberFormat;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.springframework.data.convert.EntityInstantiators;
 import org.springframework.data.jdbc.core.DataAccessStrategy;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.jdbc.repository.RowMapperMap;
@@ -76,8 +79,8 @@ public class JdbcQueryLookupStrategyUnitTests {
 
 	private RepositoryQuery getRepositoryQuery(String name, RowMapperMap rowMapperMap) {
 
-		JdbcQueryLookupStrategy queryLookupStrategy = new JdbcQueryLookupStrategy(mappingContext, accessStrategy,
-				rowMapperMap, operations);
+		JdbcQueryLookupStrategy queryLookupStrategy = new JdbcQueryLookupStrategy(mappingContext, new EntityInstantiators(),
+				accessStrategy, rowMapperMap, operations);
 
 		return queryLookupStrategy.resolveQuery(getMethod(name), metadata, projectionFactory, namedQueries);
 	}

--- a/src/test/java/org/springframework/data/jdbc/testing/TestConfiguration.java
+++ b/src/test/java/org/springframework/data/jdbc/testing/TestConfiguration.java
@@ -25,6 +25,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.convert.EntityInstantiators;
 import org.springframework.data.jdbc.core.DataAccessStrategy;
 import org.springframework.data.jdbc.core.DefaultDataAccessStrategy;
 import org.springframework.data.jdbc.core.SqlGeneratorSource;
@@ -71,7 +72,7 @@ public class TestConfiguration {
 
 	@Bean
 	DataAccessStrategy defaultDataAccessStrategy(JdbcMappingContext context) {
-		return new DefaultDataAccessStrategy(new SqlGeneratorSource(context), context, namedParameterJdbcTemplate());
+		return new DefaultDataAccessStrategy(new SqlGeneratorSource(context), context, namedParameterJdbcTemplate(), new EntityInstantiators());
 	}
 
 	@Bean


### PR DESCRIPTION
Replaced the direct use of EntityInstantiator with EntityInstantiators.
Moved it into the MappingContext because instantiation is part of the mapping process.