### PR TITLE
Renamed *.r2dbc.repository to *r2dbc.repository.reactive to match the…

### DIFF
--- a/src/main/java/org/springframework/data/r2dbc/repository/reactive/R2dbcRepository.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/reactive/R2dbcRepository.java
@@ -13,24 +13,15 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.r2dbc.repository.query;
+package org.springframework.data.r2dbc.repository.reactive;
 
-import java.util.function.Supplier;
-
-import org.springframework.data.r2dbc.function.DatabaseClient.BindSpec;
+import org.springframework.data.repository.NoRepositoryBean;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 
 /**
- * Interface declaring a query that supplies SQL and can bind parameters to a {@link BindSpec}.
+ * R2DBC specific {@link org.springframework.data.repository.Repository} interface with reactive support.
  *
  * @author Mark Paluch
  */
-public interface BindableQuery extends Supplier<String> {
-
-	/**
-	 * Bind parameters to the {@link BindSpec query}.
-	 *
-	 * @param bindSpec must not be {@literal null}.
-	 * @return the bound query object.
-	 */
-	<T extends BindSpec<T>> T bind(T bindSpec);
-}
+@NoRepositoryBean
+public interface R2dbcRepository<T, ID> extends ReactiveCrudRepository<T, ID> {}

--- a/src/main/java/org/springframework/data/r2dbc/repository/reactive/package-info.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/reactive/package-info.java
@@ -2,6 +2,6 @@
  * R2DBC-specific repository implementation.
  */
 @NonNullApi
-package org.springframework.data.r2dbc.repository;
+package org.springframework.data.r2dbc.repository.reactive;
 
 import org.springframework.lang.NonNullApi;

--- a/src/main/java/org/springframework/data/r2dbc/repository/reactive/query/AbstractR2dbcQuery.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/reactive/query/AbstractR2dbcQuery.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.r2dbc.repository.query;
+package org.springframework.data.r2dbc.repository.reactive.query;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -25,8 +25,8 @@ import org.springframework.data.r2dbc.function.DatabaseClient;
 import org.springframework.data.r2dbc.function.DatabaseClient.GenericExecuteSpec;
 import org.springframework.data.r2dbc.function.FetchSpec;
 import org.springframework.data.r2dbc.function.convert.MappingR2dbcConverter;
-import org.springframework.data.r2dbc.repository.query.R2dbcQueryExecution.ResultProcessingConverter;
-import org.springframework.data.r2dbc.repository.query.R2dbcQueryExecution.ResultProcessingExecution;
+import org.springframework.data.r2dbc.repository.reactive.query.R2dbcQueryExecution.ResultProcessingConverter;
+import org.springframework.data.r2dbc.repository.reactive.query.R2dbcQueryExecution.ResultProcessingExecution;
 import org.springframework.data.relational.repository.query.RelationalParameterAccessor;
 import org.springframework.data.relational.repository.query.RelationalParametersParameterAccessor;
 import org.springframework.data.repository.query.ParameterAccessor;

--- a/src/main/java/org/springframework/data/r2dbc/repository/reactive/query/BindableQuery.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/reactive/query/BindableQuery.java
@@ -13,15 +13,24 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.r2dbc.repository;
+package org.springframework.data.r2dbc.repository.reactive.query;
 
-import org.springframework.data.repository.NoRepositoryBean;
-import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import java.util.function.Supplier;
+
+import org.springframework.data.r2dbc.function.DatabaseClient.BindSpec;
 
 /**
- * R2DBC specific {@link org.springframework.data.repository.Repository} interface with reactive support.
+ * Interface declaring a query that supplies SQL and can bind parameters to a {@link BindSpec}.
  *
  * @author Mark Paluch
  */
-@NoRepositoryBean
-public interface R2dbcRepository<T, ID> extends ReactiveCrudRepository<T, ID> {}
+public interface BindableQuery extends Supplier<String> {
+
+	/**
+	 * Bind parameters to the {@link BindSpec query}.
+	 *
+	 * @param bindSpec must not be {@literal null}.
+	 * @return the bound query object.
+	 */
+	<T extends BindSpec<T>> T bind(T bindSpec);
+}

--- a/src/main/java/org/springframework/data/r2dbc/repository/reactive/query/R2dbcParameterAccessor.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/reactive/query/R2dbcParameterAccessor.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.r2dbc.repository.query;
+package org.springframework.data.r2dbc.repository.reactive.query;
 
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;

--- a/src/main/java/org/springframework/data/r2dbc/repository/reactive/query/R2dbcQueryExecution.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/reactive/query/R2dbcQueryExecution.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.r2dbc.repository.query;
+package org.springframework.data.r2dbc.repository.reactive.query;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/springframework/data/r2dbc/repository/reactive/query/R2dbcQueryMethod.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/reactive/query/R2dbcQueryMethod.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.r2dbc.repository.query;
+package org.springframework.data.r2dbc.repository.reactive.query;
 
 import static org.springframework.data.repository.util.ClassUtils.*;
 

--- a/src/main/java/org/springframework/data/r2dbc/repository/reactive/query/StringBasedR2dbcQuery.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/reactive/query/StringBasedR2dbcQuery.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.r2dbc.repository.query;
+package org.springframework.data.r2dbc.repository.reactive.query;
 
 import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.r2dbc.function.DatabaseClient;

--- a/src/main/java/org/springframework/data/r2dbc/repository/reactive/query/package-info.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/reactive/query/package-info.java
@@ -3,7 +3,7 @@
  */
 @NonNullApi
 @NonNullFields
-package org.springframework.data.r2dbc.repository.query;
+package org.springframework.data.r2dbc.repository.reactive.query;
 
 import org.springframework.lang.NonNullApi;
 import org.springframework.lang.NonNullFields;

--- a/src/main/java/org/springframework/data/r2dbc/repository/reactive/support/R2dbcRepositoryFactory.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/reactive/support/R2dbcRepositoryFactory.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.r2dbc.repository.support;
+package org.springframework.data.r2dbc.repository.reactive.support;
 
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
@@ -27,9 +27,9 @@ import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.projection.ProjectionFactory;
 import org.springframework.data.r2dbc.function.DatabaseClient;
 import org.springframework.data.r2dbc.function.convert.MappingR2dbcConverter;
-import org.springframework.data.r2dbc.repository.R2dbcRepository;
-import org.springframework.data.r2dbc.repository.query.R2dbcQueryMethod;
-import org.springframework.data.r2dbc.repository.query.StringBasedR2dbcQuery;
+import org.springframework.data.r2dbc.repository.reactive.R2dbcRepository;
+import org.springframework.data.r2dbc.repository.reactive.query.R2dbcQueryMethod;
+import org.springframework.data.r2dbc.repository.reactive.query.StringBasedR2dbcQuery;
 import org.springframework.data.relational.repository.query.RelationalEntityInformation;
 import org.springframework.data.relational.repository.support.MappingRelationalEntityInformation;
 import org.springframework.data.repository.core.NamedQueries;

--- a/src/main/java/org/springframework/data/r2dbc/repository/reactive/support/SimpleR2dbcRepository.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/reactive/support/SimpleR2dbcRepository.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.r2dbc.repository.support;
+package org.springframework.data.r2dbc.repository.reactive.support;
 
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/springframework/data/r2dbc/repository/reactive/support/package-info.java
+++ b/src/main/java/org/springframework/data/r2dbc/repository/reactive/support/package-info.java
@@ -2,6 +2,6 @@
  * Support infrastructure for query derivation of R2DBC-specific repositories.
  */
 @NonNullApi
-package org.springframework.data.r2dbc.repository.support;
+package org.springframework.data.r2dbc.repository.reactive.support;
 
 import org.springframework.lang.NonNullApi;

--- a/src/test/java/org/springframework/data/jdbc/degraph/DependencyTests.java
+++ b/src/test/java/org/springframework/data/jdbc/degraph/DependencyTests.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.*;
 import de.schauderhaft.degraph.check.JCheck;
 import scala.runtime.AbstractFunction1;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -38,13 +37,17 @@ public class DependencyTests {
 				classpath() //
 						.noJars() //
 						.including("org.springframework.data.jdbc.**") //
+						.including("org.springframework.data.relational.**") //
+						.including("org.springframework.data.r2dbc.**") //
 						.filterClasspath("*target/classes") // exclude test code
+						.withSlicing("modules",
+								"org.springframework.data.(*).**"
+								)
 						.printOnFailure("degraph.graphml"),
 				JCheck.violationFree());
 	}
 
 	@Test // DATAJDBC-220
-	@Ignore("I don't understand why this fails after adding reactive repos - mp911de")
 	public void acrossModules() {
 
 		assertThat( //
@@ -60,8 +63,12 @@ public class DependencyTests {
 						}) // exclude test code
 						.withSlicing("sub-modules", // sub-modules are defined by any of the following pattern.
 								"org.springframework.data.jdbc.(**).*", //
+								"org.springframework.data.relational.(**).*", //
+								"org.springframework.data.r2dbc.(**).*", //
 								"org.springframework.data.(**).*") //
 						.printTo("degraph-across-modules.graphml"), // writes a graphml to this location
 				JCheck.violationFree());
 	}
+
+
 }

--- a/src/test/java/org/springframework/data/r2dbc/repository/reactive/R2dbcRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/reactive/R2dbcRepositoryIntegrationTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.r2dbc.repository;
+package org.springframework.data.r2dbc.repository.reactive;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -38,7 +38,7 @@ import org.springframework.data.jdbc.repository.query.Query;
 import org.springframework.data.jdbc.testing.R2dbcIntegrationTestSupport;
 import org.springframework.data.r2dbc.function.DatabaseClient;
 import org.springframework.data.r2dbc.function.DefaultReactiveDataAccessStrategy;
-import org.springframework.data.r2dbc.repository.support.R2dbcRepositoryFactory;
+import org.springframework.data.r2dbc.repository.reactive.support.R2dbcRepositoryFactory;
 import org.springframework.data.repository.reactive.ReactiveCrudRepository;
 import org.springframework.jdbc.core.JdbcTemplate;
 

--- a/src/test/java/org/springframework/data/r2dbc/repository/reactive/query/R2dbcQueryMethodUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/reactive/query/R2dbcQueryMethodUnitTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.r2dbc.repository.query;
+package org.springframework.data.r2dbc.repository.reactive.query;
 
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/test/java/org/springframework/data/r2dbc/repository/reactive/query/StringBasedR2dbcQueryUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/reactive/query/StringBasedR2dbcQueryUnitTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.r2dbc.repository.query;
+package org.springframework.data.r2dbc.repository.reactive.query;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;

--- a/src/test/java/org/springframework/data/r2dbc/repository/reactive/support/R2dbcRepositoryFactoryUnitTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/reactive/support/R2dbcRepositoryFactoryUnitTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.r2dbc.repository.support;
+package org.springframework.data.r2dbc.repository.reactive.support;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;

--- a/src/test/java/org/springframework/data/r2dbc/repository/reactive/support/SimpleR2dbcRepositoryIntegrationTests.java
+++ b/src/test/java/org/springframework/data/r2dbc/repository/reactive/support/SimpleR2dbcRepositoryIntegrationTests.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.springframework.data.r2dbc.repository.support;
+package org.springframework.data.r2dbc.repository.reactive.support;
 
 import static org.assertj.core.api.Assertions.*;
 


### PR DESCRIPTION
… package name for reactive repository stuff in commons.

Also reenabled the DependencyTest which now longer fails.
Adapted the other test to check the new packages as well.