### PR TITLE
DATAJDBC-218 - Add support for key column in @Column annotation

### DIFF
--- a/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
+++ b/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
@@ -38,6 +38,7 @@ import org.springframework.util.ClassUtils;
  *
  * @author Jens Schauder
  * @author Greg Turnquist
+ * @author Florian Lüdiger
  */
 class BasicRelationalPersistentProperty extends AnnotationBasedPersistentProperty<RelationalPersistentProperty>
 		implements RelationalPersistentProperty {
@@ -52,6 +53,7 @@ class BasicRelationalPersistentProperty extends AnnotationBasedPersistentPropert
 
 	private final RelationalMappingContext context;
 	private final Lazy<Optional<String>> columnName;
+	private final Lazy<Optional<String>> keyColumnName;
 
 	/**
 	 * Creates a new {@link AnnotationBasedPersistentProperty}.
@@ -70,6 +72,7 @@ class BasicRelationalPersistentProperty extends AnnotationBasedPersistentPropert
 
 		this.context = context;
 		this.columnName = Lazy.of(() -> Optional.ofNullable(findAnnotation(Column.class)).map(Column::value));
+		this.keyColumnName = Lazy.of(() -> Optional.ofNullable(findAnnotation(Column.class)).map(Column::keyColumn));
 	}
 
 	/*
@@ -116,7 +119,10 @@ class BasicRelationalPersistentProperty extends AnnotationBasedPersistentPropert
 
 	@Override
 	public String getKeyColumn() {
-		return isQualified() ? context.getNamingStrategy().getKeyColumn(this) : null;
+		if (isQualified())
+			return keyColumnName.get().orElseGet(() -> context.getNamingStrategy().getKeyColumn(this));
+		else
+			return null;
 	}
 
 	@Override

--- a/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
+++ b/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
@@ -72,7 +72,8 @@ class BasicRelationalPersistentProperty extends AnnotationBasedPersistentPropert
 
 		this.context = context;
 		this.columnName = Lazy.of(() -> Optional.ofNullable(findAnnotation(Column.class)).map(Column::value));
-		this.keyColumnName = Lazy.of(() -> Optional.ofNullable(findAnnotation(Column.class)).map(Column::keyColumn));
+		this.keyColumnName = Lazy.of(() -> Optional.ofNullable(
+				findAnnotation(Column.class)).map(Column::keyColumn).filter(keyColumn -> !keyColumn.equals("")));
 	}
 
 	/*

--- a/src/main/java/org/springframework/data/relational/core/mapping/Column.java
+++ b/src/main/java/org/springframework/data/relational/core/mapping/Column.java
@@ -25,6 +25,7 @@ import java.lang.annotation.Target;
  * The annotation to configure the mapping from an attribute to a database column.
  *
  * @author Kazuki Shimizu
+ * @author Florian Lüdiger
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
@@ -35,4 +36,9 @@ public @interface Column {
 	 * The mapping column name.
 	 */
 	String value();
+
+	/**
+	 * The column name for key columns of List or Map collections.
+	 */
+	String keyColumn() default "";
 }

--- a/src/test/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentPropertyUnitTests.java
+++ b/src/test/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentPropertyUnitTests.java
@@ -22,6 +22,7 @@ import lombok.Data;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.Date;
+import java.util.List;
 import java.util.UUID;
 
 import org.assertj.core.api.SoftAssertions;
@@ -33,6 +34,7 @@ import org.springframework.data.mapping.PropertyHandler;
  *
  * @author Jens Schauder
  * @author Oliver Gierke
+ * @author Florian Lüdiger
  */
 public class BasicRelationalPersistentPropertyUnitTests {
 
@@ -84,6 +86,17 @@ public class BasicRelationalPersistentPropertyUnitTests {
 				.isEqualTo("dummy_last_updated_at");
 	}
 
+	@Test // DATAJDBC-218
+	public void detectsAnnotatedColumnAndKeyName() {
+
+		RelationalPersistentEntity<?> entity = context.getRequiredPersistentEntity(DummyEntity.class);
+
+		assertThat(entity.getRequiredPersistentProperty("someList").getColumnName())
+				.isEqualTo("dummy_column_name");
+		assertThat(entity.getRequiredPersistentProperty("someList").getKeyColumn())
+				.isEqualTo("dummy_key_column_name");
+	}
+
 	private void checkTargetType(SoftAssertions softly, RelationalPersistentEntity<?> persistentEntity,
 			String propertyName, Class<?> expected) {
 
@@ -99,6 +112,9 @@ public class BasicRelationalPersistentPropertyUnitTests {
 		private final LocalDateTime localDateTime;
 		private final ZonedDateTime zonedDateTime;
 		private final UUID uuid;
+
+		@Column(value="dummy_column_name", keyColumn="dummy_key_column_name")
+		private List<Integer> someList;
 
 		// DATACMNS-106
 		private @Column("dummy_name") String name;


### PR DESCRIPTION
This adds the functionality requested in [DATAJDBC-218](https://jira.spring.io/browse/DATAJDBC-218), so you can now customize the key column name for List and Map collections inside the @Column annotation.

I have also added a test case to demonstrate the behavior.