### PR TITLE
DATAJDBC-252 - Properties only get set if they are not part of the constructor.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.springframework.data</groupId>
     <artifactId>spring-data-jdbc</artifactId>
-    <version>1.0.0.BUILD-SNAPSHOT</version>
+    <version>1.0.0.DATAJDBC-252-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>

--- a/src/main/java/org/springframework/data/jdbc/core/EntityRowMapper.java
+++ b/src/main/java/org/springframework/data/jdbc/core/EntityRowMapper.java
@@ -71,13 +71,13 @@ public class EntityRowMapper<T> implements RowMapper<T> {
 		T result = createInstance(entity, resultSet, "");
 
 		if (entity.requiresPropertyPopulation()) {
-			populateProperties(result, resultSet);
+			return populateProperties(result, resultSet);
 		}
 
 		return result;
 	}
 
-	private void populateProperties(T result, ResultSet resultSet) {
+	private T populateProperties(T result, ResultSet resultSet) {
 
 		PersistentPropertyAccessor<T> propertyAccessor = converter.getPropertyAccessor(entity, result);
 
@@ -101,6 +101,8 @@ public class EntityRowMapper<T> implements RowMapper<T> {
 				propertyAccessor.setProperty(property, readFrom(resultSet, property, ""));
 			}
 		}
+
+		return propertyAccessor.getBean();
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/jdbc/core/EntityRowMapper.java
+++ b/src/main/java/org/springframework/data/jdbc/core/EntityRowMapper.java
@@ -70,6 +70,15 @@ public class EntityRowMapper<T> implements RowMapper<T> {
 
 		T result = createInstance(entity, resultSet, "");
 
+		if (entity.requiresPropertyPopulation()) {
+			populateProperties(result, resultSet);
+		}
+
+		return result;
+	}
+
+	private void populateProperties(T result, ResultSet resultSet) {
+
 		PersistentPropertyAccessor<T> propertyAccessor = converter.getPropertyAccessor(entity, result);
 
 		Object id = idProperty == null ? null : readFrom(resultSet, idProperty, "");
@@ -92,8 +101,6 @@ public class EntityRowMapper<T> implements RowMapper<T> {
 				propertyAccessor.setProperty(property, readFrom(resultSet, property, ""));
 			}
 		}
-
-		return result;
 	}
 
 	/**

--- a/src/main/java/org/springframework/data/jdbc/core/EntityRowMapper.java
+++ b/src/main/java/org/springframework/data/jdbc/core/EntityRowMapper.java
@@ -23,6 +23,7 @@ import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.mapping.MappingException;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
+import org.springframework.data.mapping.PreferredConstructor;
 import org.springframework.data.relational.core.conversion.RelationalConverter;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
@@ -73,7 +74,13 @@ public class EntityRowMapper<T> implements RowMapper<T> {
 
 		Object id = idProperty == null ? null : readFrom(resultSet, idProperty, "");
 
+		PreferredConstructor<T, RelationalPersistentProperty> persistenceConstructor = entity.getPersistenceConstructor();
+
 		for (RelationalPersistentProperty property : entity) {
+
+			if (persistenceConstructor != null && persistenceConstructor.isConstructorParameter(property)) {
+				continue;
+			}
 
 			if (property.isCollectionLike() && id != null) {
 				propertyAccessor.setProperty(property, accessStrategy.findAllByProperty(id, property));

--- a/src/test/java/org/springframework/data/jdbc/repository/query/QueryAnnotationHsqlIntegrationTests.java
+++ b/src/test/java/org/springframework/data/jdbc/repository/query/QueryAnnotationHsqlIntegrationTests.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import lombok.Value;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -251,6 +252,12 @@ public class QueryAnnotationHsqlIntegrationTests {
 		assertThat(repository.findByNameAsEntity("Spring Data JDBC")).isNotNull();
 	}
 
+	@Test // DATAJDBC-175
+	public void executeCustomQueryWithImmutableResultType() {
+
+		assertThat(repository.immutableTuple()).isEqualTo(new DummyEntityRepository.ImmutableTuple("one", "two", 3));
+	}
+
 	private DummyEntity dummyEntity(String name) {
 
 		DummyEntity entity = new DummyEntity();
@@ -329,5 +336,16 @@ public class QueryAnnotationHsqlIntegrationTests {
 		@Query("INSERT INTO DUMMY_ENTITY (name) VALUES(:name)")
 		void insert(@Param("name") String name);
 
+		// DATAJDBC-252
+		@Query("SELECT 'one' one, 'two' two, 3 three FROM (VALUES (0))")
+		ImmutableTuple immutableTuple();
+
+
+		@Value
+		class ImmutableTuple {
+			String one;
+			String two;
+			int three;
+		}
 	}
 }


### PR DESCRIPTION
For mutable entities this avoids superfluous setting of attributes.
For imutables without "Wither"s this avoids failures due to not being able to set a property.