### PR TITLE
DATAJDBC-264 - Fix insert query for empty nonIdColumnNames 

### DIFF
--- a/src/main/java/org/springframework/data/jdbc/core/SqlGenerator.java
+++ b/src/main/java/org/springframework/data/jdbc/core/SqlGenerator.java
@@ -260,7 +260,9 @@ class SqlGenerator {
 		columnNamesForInsert.addAll(additionalColumns);
 
 		String tableColumns = String.join(", ", columnNamesForInsert);
-		String parameterNames = columnNamesForInsert.stream().collect(Collectors.joining(", :", ":", ""));
+		String parameterNames = columnNamesForInsert.stream()//
+				.map(n -> String.format(":%s", n))//
+				.collect(Collectors.joining(", "));
 
 		return String.format(insertTemplate, entity.getTableName(), tableColumns, parameterNames);
 	}


### PR DESCRIPTION
SqlGenerator.createInsertSql fails to generate sql when nonIdColumnNames is empty.
This method outputs like this:
```
INSERT INTO sample_table () VALUES (:)
```

This pull request fixes this behaivor. It uses the way of createUpdateSql instead of Collectors.joining(delimiter, prefix, suffix).