### PR TITLE
DATAJDBC-267 - Fix Jdbc configuration to support multiple stores

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>org.springframework.data</groupId>
     <artifactId>spring-data-jdbc</artifactId>
-    <version>1.0.0.BUILD-SNAPSHOT</version>
+    <version>1.0.0.DATAJDBC-267-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>

--- a/src/main/java/org/springframework/data/jdbc/repository/config/JdbcConfiguration.java
+++ b/src/main/java/org/springframework/data/jdbc/repository/config/JdbcConfiguration.java
@@ -33,31 +33,30 @@ import org.springframework.data.relational.core.mapping.RelationalMappingContext
  * @author Greg Turnquist
  * @author Jens Schauder
  * @author Mark Paluch
+ * @author Michael Simons
  */
 @Configuration
 public class JdbcConfiguration {
 
 	@Bean
-	protected RelationalMappingContext jdbcMappingContext(Optional<NamingStrategy> namingStrategy,
-			CustomConversions customConversions) {
+	protected RelationalMappingContext jdbcMappingContext(Optional<NamingStrategy> namingStrategy) {
 
 		RelationalMappingContext mappingContext = new RelationalMappingContext(
 				namingStrategy.orElse(NamingStrategy.INSTANCE));
-		mappingContext.setSimpleTypeHolder(customConversions.getSimpleTypeHolder());
+		mappingContext.setSimpleTypeHolder(jdbcCustomConversions().getSimpleTypeHolder());
 
 		return mappingContext;
 	}
 
 	@Bean
-	protected RelationalConverter relationalConverter(RelationalMappingContext mappingContext,
-			CustomConversions customConversions) {
-		return new BasicRelationalConverter(mappingContext, customConversions);
+	protected RelationalConverter relationalConverter(RelationalMappingContext mappingContext) {
+		return new BasicRelationalConverter(mappingContext, jdbcCustomConversions());
 	}
 
 	/**
 	 * Register custom {@link Converter}s in a {@link CustomConversions} object if required. These
 	 * {@link CustomConversions} will be registered with the
-	 * {@link #relationalConverter(RelationalMappingContext, CustomConversions)}. Returns an empty
+	 * {@link #relationalConverter(RelationalMappingContext)}. Returns an empty
 	 * {@link JdbcCustomConversions} instance by default.
 	 *
 	 * @return must not be {@literal null}.


### PR DESCRIPTION
I spoke briefly with @schauder about that change to fix DATAJDBC-267 while he is on the plane. Would you mind having a look @mp911de ? This is pretty much the same behavior data-mongo has, but I couldn't find a test for the specific `JdbcConfiguration` class. AFAIK it is never actually invoked during the current JDBC tests.