### PR TITLE
 DATAJDBC-347 - Add missing override to SelectBuilder. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>1.1.0.BUILD-SNAPSHOT</version>
+	<version>1.1.0.DATAJDBC-347-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/SelectBuilder.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/SelectBuilder.java
@@ -114,6 +114,18 @@ public interface SelectBuilder {
 		 * Declare a {@link Table} to {@code SELECT … FROM}. Multiple calls to this or other {@code from} methods keep
 		 * adding items to the select list and do not replace previously contained items.
 		 *
+		 * @param table the table name to {@code SELECT … FROM} must not be {@literal null} or empty.
+		 * @return {@code this} builder.
+		 * @see From
+		 * @see SQL#table(String)
+		 */
+		@Override
+		SelectFromAndJoin from(String table);
+
+		/**
+		 * Declare a {@link Table} to {@code SELECT … FROM}. Multiple calls to this or other {@code from} methods keep
+		 * adding items to the select list and do not replace previously contained items.
+		 *
 		 * @param table the table to {@code SELECT … FROM} must not be {@literal null}.
 		 * @return {@code this} builder.
 		 * @see From

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/SelectBuilderUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/SelectBuilderUnitTests.java
@@ -17,11 +17,10 @@ package org.springframework.data.relational.core.sql;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.OptionalLong;
 
 import org.junit.Test;
+
 import org.springframework.data.relational.core.sql.Join.JoinType;
 
 /**
@@ -63,6 +62,23 @@ public class SelectBuilderUnitTests {
 
 		assertThat(visitor.enter).containsSequence(foo, table, new From(table), table);
 		assertThat(select.getLimit()).isEqualTo(OptionalLong.of(10));
+	}
+
+	@Test // DATAJDBC-347
+	public void selectWithWhere() {
+
+		SelectBuilder builder = StatementBuilder.select();
+
+		Table table = SQL.table("mytable");
+		Column foo = table.column("foo");
+
+		Comparison condition = foo.isEqualTo(SQL.literalOf("bar"));
+		Select select = builder.select(foo).from(table.getName()).where(condition).build();
+
+		CapturingVisitor visitor = new CapturingVisitor();
+		select.visit(visitor);
+
+		assertThat(visitor.enter).containsSequence(foo, table, new From(table), table, new Where(condition));
 	}
 
 	@Test // DATAJDBC-309


### PR DESCRIPTION
`SelectAndFrom` now overrides all `from(…)`methods to return the appropriate builder continuation type.

---

Related ticket: [DATAJDBC-347](https://jira.spring.io/browse/DATAJDBC-347).