### PR TITLE
DATAJDBC-355 - Remove unnecessary null check.

### DIFF
--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCustomConversionIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCustomConversionIntegrationTests.java
@@ -39,7 +39,6 @@ import org.springframework.data.jdbc.core.convert.JdbcValue;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.repository.CrudRepository;
-import org.springframework.lang.Nullable;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.rules.SpringClassRule;
 import org.springframework.test.context.junit4.rules.SpringMethodRule;
@@ -93,9 +92,9 @@ public class JdbcRepositoryCustomConversionIntegrationTests {
 	 *
 	 * 	&#64;Override
 	 * 	&#64;Nullable
-	 * 	public BigDecimal convert(@Nullable String source) {
+	 * 	public BigDecimal convert(String source) {
 	 *
-	 * 		return source == null ? null : new BigDecimal(source);
+	 * 		return source == new BigDecimal(source);
 	 * 	}
 	 * }
 	 * </pre>
@@ -130,9 +129,9 @@ public class JdbcRepositoryCustomConversionIntegrationTests {
 		INSTANCE;
 
 		@Override
-		public JdbcValue convert(@Nullable String source) {
+		public JdbcValue convert(String source) {
 
-			Object value = source == null ? null : new BigDecimal(source);
+			Object value = new BigDecimal(source);
 			return JdbcValue.of(value, JDBCType.DECIMAL);
 		}
 
@@ -144,11 +143,7 @@ public class JdbcRepositoryCustomConversionIntegrationTests {
 		INSTANCE;
 
 		@Override
-		public String convert(@Nullable BigDecimal source) {
-
-			if (source == null) {
-				return null;
-			}
+		public String convert(BigDecimal source) {
 
 			return source.toString();
 		}


### PR DESCRIPTION
The following logic to check null value seems unnecessary.

```java
	@ReadingConverter
	enum BigDecimalToString implements Converter<BigDecimal, String> {

		INSTANCE;

		@Override
		public String convert(@Nullable BigDecimal source) {

			if (source == null) {
				return null;
			}

			return source.toString();
		}
	}
```


The source parameter must not be null according to Javadoc of Converter.

https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/core/convert/converter/Converter.html