### PR TITLE
DATAJDBC-374 - Add onEmpty attribute to Embedded annotation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
 		<postgresql.version>42.0.0</postgresql.version>
 		<mariadb-java-client.version>2.2.3</mariadb-java-client.version>
 		<testcontainers.version>1.9.1</testcontainers.version>
+		<jsr305.version>3.0.2</jsr305.version>
 	</properties>
 
 	<inceptionYear>2017</inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>1.1.0.BUILD-SNAPSHOT</version>
+	<version>1.1.0.DATAJDBC-374-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>1.1.0.BUILD-SNAPSHOT</version>
+		<version>1.1.0.DATAJDBC-374-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>1.1.0.BUILD-SNAPSHOT</version>
+	<version>1.1.0.DATAJDBC-374-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>1.1.0.BUILD-SNAPSHOT</version>
+		<version>1.1.0.DATAJDBC-374-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/BasicJdbcConverter.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/BasicJdbcConverter.java
@@ -36,6 +36,8 @@ import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
 import org.springframework.data.relational.core.conversion.BasicRelationalConverter;
 import org.springframework.data.relational.core.conversion.RelationalConverter;
+import org.springframework.data.relational.core.mapping.Embedded;
+import org.springframework.data.relational.core.mapping.Embedded.OnEmpty;
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
@@ -352,6 +354,11 @@ public class BasicJdbcConverter extends BasicRelationalConverter implements Jdbc
 		private Object readEmbeddedEntityFrom(@Nullable Object idValue, RelationalPersistentProperty property) {
 
 			ReadingContext<?> newContext = extendBy(property);
+
+			if(OnEmpty.USE_EMPTY.equals(property.findAnnotation(Embedded.class).onEmpty())) {
+				return newContext.createInstanceInternal(idValue);
+			}
+
 			return newContext.hasInstanceValues(idValue) ? newContext.createInstanceInternal(idValue) : null;
 		}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/PersistentPropertyPathExtensionUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/PersistentPropertyPathExtensionUnitTests.java
@@ -23,6 +23,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.relational.core.mapping.Embedded;
+import org.springframework.data.relational.core.mapping.Embedded.OnEmpty;
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
@@ -217,7 +218,7 @@ public class PersistentPropertyPathExtensionUnitTests {
 	static class DummyEntity {
 		@Id Long entityId;
 		Second second;
-		@Embedded("sec") Second second2;
+		@Embedded(onEmpty = OnEmpty.USE_NULL, prefix = "sec") Second second2;
 		List<Second> secondList;
 		WithId withId;
 	}
@@ -225,7 +226,7 @@ public class PersistentPropertyPathExtensionUnitTests {
 	@SuppressWarnings("unused")
 	static class Second {
 		Third third;
-		@Embedded("thrd") Third third2;
+		@Embedded(onEmpty = OnEmpty.USE_NULL, prefix = "thrd") Third third2;
 	}
 
 	@SuppressWarnings("unused")
@@ -237,7 +238,7 @@ public class PersistentPropertyPathExtensionUnitTests {
 	static class WithId {
 		@Id Long withIdId;
 		Second second;
-		@Embedded("sec") Second second2;
+		@Embedded(onEmpty = OnEmpty.USE_NULL, prefix = "sec") Second second2;
 	}
 
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/EntityRowMapperUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/EntityRowMapperUnitTests.java
@@ -553,13 +553,13 @@ public class EntityRowMapperUnitTests {
 	static class WithEmptyEmbeddedImmutableValue {
 
 		@Id Long id;
-		@Embedded(onEmpty = OnEmpty.USE_EMPTY) ImmutableValue embeddedImmutableValue;
+		@Embedded.Empty ImmutableValue embeddedImmutableValue;
 	}
 
 	static class WithEmbeddedPrimitiveImmutableValue {
 
 		@Id Long id;
-		@Embedded(onEmpty = OnEmpty.USE_NULL) ImmutablePrimitiveValue embeddedImmutablePrimitiveValue;
+		@Embedded.Nullable ImmutablePrimitiveValue embeddedImmutablePrimitiveValue;
 	}
 
 	@Value

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorEmbeddedUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorEmbeddedUnitTests.java
@@ -27,6 +27,7 @@ import org.springframework.data.jdbc.core.PropertyPathTestingUtils;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Embedded;
+import org.springframework.data.relational.core.mapping.Embedded.OnEmpty;
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
@@ -245,16 +246,16 @@ public class SqlGeneratorEmbeddedUnitTests {
 
 		@Column("id1") @Id Long id;
 
-		@Embedded("prefix_") CascadedEmbedded prefixedEmbeddable;
+		@Embedded(onEmpty = OnEmpty.USE_NULL, prefix = "prefix_") CascadedEmbedded prefixedEmbeddable;
 
-		@Embedded CascadedEmbedded embeddable;
+		@Embedded(onEmpty = OnEmpty.USE_NULL) CascadedEmbedded embeddable;
 	}
 
 	@SuppressWarnings("unused")
 	static class CascadedEmbedded {
 		String test;
-		@Embedded("prefix2_") Embeddable prefixedEmbeddable;
-		@Embedded Embeddable embeddable;
+		@Embedded(onEmpty = OnEmpty.USE_NULL, prefix = "prefix2_") Embeddable prefixedEmbeddable;
+		@Embedded(onEmpty = OnEmpty.USE_NULL) Embeddable embeddable;
 	}
 
 	@SuppressWarnings("unused")
@@ -268,7 +269,7 @@ public class SqlGeneratorEmbeddedUnitTests {
 
 		@Id Long id;
 
-		@Embedded("prefix_") EmbeddedWithReference embedded;
+		@Embedded(onEmpty = OnEmpty.USE_NULL, prefix = "prefix_") EmbeddedWithReference embedded;
 	}
 
 	static class EmbeddedWithReference {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedImmutableIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedImmutableIntegrationTests.java
@@ -33,6 +33,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.mapping.Embedded;
+import org.springframework.data.relational.core.mapping.Embedded.OnEmpty;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -99,7 +100,7 @@ public class JdbcRepositoryEmbeddedImmutableIntegrationTests {
 
 		@Id Long id;
 
-		@Embedded("prefix_") Embeddable prefixedEmbeddable;
+		@Embedded(onEmpty = OnEmpty.USE_NULL, prefix = "prefix_") Embeddable prefixedEmbeddable;
 	}
 
 	@Value

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedIntegrationTests.java
@@ -31,6 +31,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.mapping.Embedded;
+import org.springframework.data.relational.core.mapping.Embedded.OnEmpty;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -250,16 +251,16 @@ public class JdbcRepositoryEmbeddedIntegrationTests {
 
 		@Id Long id;
 
-		@Embedded("prefix_") CascadedEmbeddable prefixedEmbeddable;
+		@Embedded(onEmpty = OnEmpty.USE_NULL, prefix = "prefix_") CascadedEmbeddable prefixedEmbeddable;
 
-		@Embedded CascadedEmbeddable embeddable;
+		@Embedded(onEmpty = OnEmpty.USE_NULL) CascadedEmbeddable embeddable;
 	}
 
 	@Data
 	static class CascadedEmbeddable {
 		String test;
 
-		@Embedded("prefix2_")
+		@Embedded(onEmpty = OnEmpty.USE_NULL, prefix = "prefix2_")
 		Embeddable embeddable;
 	}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedNotInAggregateRootIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedNotInAggregateRootIntegrationTests.java
@@ -32,6 +32,7 @@ import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Embedded;
+import org.springframework.data.relational.core.mapping.Embedded.OnEmpty;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -246,7 +247,7 @@ public class JdbcRepositoryEmbeddedNotInAggregateRootIntegrationTests {
 
 		String test;
 
-		@Embedded("prefix_")
+		@Embedded(onEmpty = OnEmpty.USE_NULL, prefix = "prefix_")
 		Embeddable embeddable;
 	}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedWithCollectionIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedWithCollectionIntegrationTests.java
@@ -32,6 +32,7 @@ import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Embedded;
+import org.springframework.data.relational.core.mapping.Embedded.OnEmpty;
 import org.springframework.data.relational.core.mapping.MappedCollection;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -249,7 +250,7 @@ public class JdbcRepositoryEmbeddedWithCollectionIntegrationTests {
 
 		String test;
 
-		@Embedded("prefix_")
+		@Embedded(onEmpty = OnEmpty.USE_NULL, prefix = "prefix_")
 		Embeddable embeddable;
 	}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedWithReferenceIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryEmbeddedWithReferenceIntegrationTests.java
@@ -32,6 +32,7 @@ import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory;
 import org.springframework.data.jdbc.testing.TestConfiguration;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.Embedded;
+import org.springframework.data.relational.core.mapping.Embedded.OnEmpty;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -236,7 +237,7 @@ public class JdbcRepositoryEmbeddedWithReferenceIntegrationTests {
 
 		String test;
 
-		@Embedded("prefix_")
+		@Embedded(onEmpty = OnEmpty.USE_NULL, prefix = "prefix_")
 		Embeddable embeddable;
 	}
 

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>1.1.0.BUILD-SNAPSHOT</version>
+	<version>1.1.0.DATAJDBC-374-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>1.1.0.BUILD-SNAPSHOT</version>
+		<version>1.1.0.DATAJDBC-374-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -49,6 +49,13 @@
 		</dependency>
 
 		<dependency>
+			<groupId>com.google.code.findbugs</groupId>
+			<artifactId>jsr305</artifactId>
+			<version>${jsr305.version}</version>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<version>${assertj}</version>

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
@@ -84,7 +84,7 @@ public class BasicRelationalPersistentProperty extends AnnotationBasedPersistent
 		this.isEmbedded = Lazy.of(() -> Optional.ofNullable(findAnnotation(Embedded.class)).isPresent());
 
 		this.embeddedPrefix = Lazy.of(() -> Optional.ofNullable(findAnnotation(Embedded.class)) //
-				.map(Embedded::value) //
+				.map(Embedded::prefix) //
 				.orElse(""));
 
 		this.columnName = Lazy.of(() -> Optional.ofNullable(findAnnotation(Column.class)) //

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/Embedded.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/Embedded.java
@@ -21,6 +21,10 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import javax.annotation.meta.When;
+
+import org.springframework.core.annotation.AliasFor;
+
 /**
  * The annotation to configure a value object as embedded in the current table.
  * <p />
@@ -38,6 +42,8 @@ public @interface Embedded {
 
 	/**
 	 * Set the load strategy for the embedded object if all contained fields yield {@literal null} values.
+	 * <p />
+	 * {@link Nullable @Embedded.Nullable} and {@link Empty @Embedded.Empty} offer shortcuts for this.
 	 * 
 	 * @return never {@link} null.
 	 */
@@ -56,5 +62,85 @@ public @interface Embedded {
 	 */
 	enum OnEmpty {
 		USE_NULL, USE_EMPTY
+	}
+
+	/**
+	 * Shortcut for a nullable embedded property.
+	 *
+	 * <pre>
+	 * <code>
+	 * &#64;Embedded.Nullable
+	 * private Address address;
+	 * </code>
+	 * </pre>
+	 * 
+	 * as alternative to the more verbose
+	 * 
+	 * <pre>
+	 * <code>
+	 *
+	 * &#64;Embedded(onEmpty = USE_NULL)
+	 * &#64;javax.annotation.Nonnull(when = When.MAYBE)
+	 * private Address address;
+	 *
+	 * </code>
+	 * </pre>
+	 *
+	 * @author Christoph Strobl
+	 * @since 1.1
+	 * @see Embedded#onEmpty()
+	 */
+	@Embedded(onEmpty = OnEmpty.USE_NULL)
+	@Documented
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.FIELD, ElementType.METHOD })
+	@javax.annotation.Nonnull(when = When.MAYBE)
+	@interface Nullable {
+
+		/**
+		 * @return prefix for columns in the embedded value object. An empty {@link String} by default.
+		 */
+		@AliasFor(annotation = Embedded.class, attribute = "prefix")
+		String prefix() default "";
+	}
+
+	/**
+	 * Shortcut for an empty embedded property.
+	 *
+	 * <pre>
+	 * <code>
+	 * &#64;Embedded.Empty
+	 * private Address address;
+	 * </code>
+	 * </pre>
+	 *
+	 * as alternative to the more verbose
+	 *
+	 * <pre>
+	 * <code>
+	 *
+	 * &#64;Embedded(onEmpty = USE_EMPTY)
+	 * &#64;javax.annotation.Nonnull(when = When.NEVER)
+	 * private Address address;
+	 *
+	 * </code>
+	 * </pre>
+	 *
+	 * @author Christoph Strobl
+	 * @since 1.1
+	 * @see Embedded#onEmpty()
+	 */
+	@Embedded(onEmpty = OnEmpty.USE_EMPTY)
+	@Documented
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target({ ElementType.FIELD, ElementType.METHOD })
+	@javax.annotation.Nonnull(when = When.NEVER)
+	@interface Empty {
+
+		/**
+		 * @return prefix for columns in the embedded value object. An empty {@link String} by default.
+		 */
+		@AliasFor(annotation = Embedded.class, attribute = "prefix")
+		String prefix() default "";
 	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/Embedded.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/Embedded.java
@@ -23,15 +23,38 @@ import java.lang.annotation.Target;
 
 /**
  * The annotation to configure a value object as embedded in the current table.
+ * <p />
+ * Depending on the {@link OnEmpty value} of {@link #onEmpty()} the property is set to {@literal null} or an empty
+ * instance in the case all embedded values are {@literal null} when reading from the result set.
  *
  * @author Bastian Wilhelm
+ * @author Christoph Strobl
+ * @since 1.1
  */
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.ANNOTATION_TYPE })
 @Documented
 public @interface Embedded {
-  /**
-   * @return prefix for columns in the embedded value object. Default is an empty String
-   */
-  String value() default "";
+
+	/**
+	 * Set the load strategy for the embedded object if all contained fields yield {@literal null} values.
+	 * 
+	 * @return never {@link} null.
+	 */
+	OnEmpty onEmpty();
+
+	/**
+	 * @return prefix for columns in the embedded value object. An empty {@link String} by default.
+	 */
+	String prefix() default "";
+
+	/**
+	 * Load strategy to be used {@link Embedded#onEmpty()}.
+	 * 
+	 * @author Christoph Strobl
+	 * @since 1.1
+	 */
+	enum OnEmpty {
+		USE_NULL, USE_EMPTY
+	}
 }

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/conversion/RelationalEntityWriterUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/conversion/RelationalEntityWriterUnitTests.java
@@ -38,6 +38,7 @@ import org.springframework.data.relational.core.conversion.DbAction.Insert;
 import org.springframework.data.relational.core.conversion.DbAction.InsertRoot;
 import org.springframework.data.relational.core.conversion.DbAction.UpdateRoot;
 import org.springframework.data.relational.core.mapping.Embedded;
+import org.springframework.data.relational.core.mapping.Embedded.OnEmpty;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 
@@ -464,7 +465,7 @@ public class RelationalEntityWriterUnitTests {
 	static class EmbeddedReferenceEntity {
 
 		@Id final Long id;
-		@Embedded("prefix_") Element other;
+		@Embedded(onEmpty = OnEmpty.USE_NULL, prefix = "prefix_") Element other;
 	}
 
 	@RequiredArgsConstructor

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentPropertyUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentPropertyUnitTests.java
@@ -30,6 +30,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.Test;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mapping.PropertyHandler;
+import org.springframework.data.relational.core.mapping.Embedded.OnEmpty;
 
 /**
  * Unit tests for the {@link BasicRelationalPersistentProperty}.
@@ -188,10 +189,10 @@ public class BasicRelationalPersistentPropertyUnitTests {
 		private @Column("dummy_name") String name;
 
 		// DATAJDBC-111
-		private @Embedded EmbeddableEntity embeddableEntity;
+		private @Embedded(onEmpty = OnEmpty.USE_NULL) EmbeddableEntity embeddableEntity;
 
 		// DATAJDBC-111
-		private @Embedded("prefix") EmbeddableEntity prefixedEmbeddableEntity;
+		private @Embedded(onEmpty = OnEmpty.USE_NULL, prefix = "prefix") EmbeddableEntity prefixedEmbeddableEntity;
 
 		@Column("dummy_last_updated_at")
 		public LocalDateTime getLocalDateTime() {

--- a/src/main/asciidoc/jdbc.adoc
+++ b/src/main/asciidoc/jdbc.adoc
@@ -314,6 +314,24 @@ public class EmbeddedEntity {
 If you need a value object multiple times in an entity, this can be achieved with the optional `prefix` element of the `@Embedded` annotation.
 This element represents a prefix and is prepend for each column name in the embedded object.
 
+[TIP]
+====
+Make use of the shortcuts `@Embedded.Nullable` & `@Embedded.Empty` for `@Embedded(onEmpty = USE_NULL)` and `@Embedded(onEmpty = USE_EMPTY)` to reduce verbositility and simultaneously set JSR-305 `@javax.annotation.Nonnull` accordingly.
+
+[source, java]
+----
+public class MyEntity {
+
+    @Id
+    Integer id;
+
+    @Embedded.Nullable <1>
+    EmbeddedEntity embeddedEntity;
+}
+----
+<1> Shortcut for `@Embedded(onEmpty = USE_NULL)`.
+====
+
 [[jdbc.entity-persistence.state-detection-strategies]]
 === Entity State Detection Strategies
 

--- a/src/main/asciidoc/jdbc.adoc
+++ b/src/main/asciidoc/jdbc.adoc
@@ -288,14 +288,19 @@ Embedded entities are used to have value objects in your java data model, even i
 In the following example you see, that `MyEntity` is mapped with the `@Embedded` annotation.
 The consequence of this is, that in the database a table `my_entity` with the two columns `id` and `name` (from the `EmbeddedEntity` class) is expected.
 
+However, if the `name` column is actually `null` within the result set, the entire property `embeddedEntity` will be set to null according to the `onEmpty` of `@Embedded`, which ``null``s objects when all nested properties are `null`. +
+Opposite to this behavior `USE_EMPTY` tries to create a new instance using either a default constructor or one that accepts nullable parameter values from the result set.
+
+.Sample Code of embedding objects
 ====
 [source, java]
 ----
 public class MyEntity {
+
     @Id
     Integer id;
 
-    @Embedded
+    @Embedded(onEmpty = USE_NULL) <1>
     EmbeddedEntity embeddedEntity;
 }
 
@@ -303,9 +308,10 @@ public class EmbeddedEntity {
     String name;
 }
 ----
+<1> ``Null``s `embeddedEntity` if `name` in `null`. Use `USE_EMPTY` to instanciate `embeddedEntity` with a potential `null` value for the `name` property.
 ====
 
-If you need a value object multiple times in an entity, this can be achieved with the optional `value` element of the `@Embedded` annotation.
+If you need a value object multiple times in an entity, this can be achieved with the optional `prefix` element of the `@Embedded` annotation.
 This element represents a prefix and is prepend for each column name in the embedded object.
 
 [[jdbc.entity-persistence.state-detection-strategies]]


### PR DESCRIPTION
The `onEmpty` attribute allows to define if an embedded entity should be set to `null` or an empty instance if all properties backing the entity are actually `null`.

```java
@Embedded(onEmpty = USE_NULL)
Address address;
```

`@Embedded.Nullable` & `@Embedded.Empty` offer shortcuts for `onEmpty = USE_NULL` and `onEmpty = USE_EMPTY` to reduce verbositility and simultaneously set JSR-305 `@javax.annotation.Nonnull` accordingly.

```java
@Embedded.Nullable
Address address;
```
