### PR TITLE
DATAJDBC-390 - RelationalAuditingEventListener now runs before other listeners without explicitly specified order.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>1.1.0.BUILD-SNAPSHOT</version>
+	<version>1.1.0.DATAJDBC-390-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>1.1.0.BUILD-SNAPSHOT</version>
+		<version>1.1.0.DATAJDBC-390-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>1.1.0.BUILD-SNAPSHOT</version>
+	<version>1.1.0.DATAJDBC-390-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>1.1.0.BUILD-SNAPSHOT</version>
+		<version>1.1.0.DATAJDBC-390-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>1.1.0.BUILD-SNAPSHOT</version>
+	<version>1.1.0.DATAJDBC-390-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>1.1.0.BUILD-SNAPSHOT</version>
+		<version>1.1.0.DATAJDBC-390-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/domain/support/RelationalAuditingEventListener.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/domain/support/RelationalAuditingEventListener.java
@@ -18,21 +18,30 @@ package org.springframework.data.relational.domain.support;
 import lombok.RequiredArgsConstructor;
 
 import org.springframework.context.ApplicationListener;
+import org.springframework.core.Ordered;
 import org.springframework.data.auditing.IsNewAwareAuditingHandler;
 import org.springframework.data.relational.core.mapping.event.BeforeSaveEvent;
 
 /**
  * Spring JDBC event listener to capture auditing information on persisting and updating entities.
  * <p>
- * An instance of this class gets registered when you apply {@link EnableJdbcAuditing} to your Spring config.
+ * An instance of this class gets registered when you enable auditing for Spring Data JDBC.
  *
  * @author Kazuki Shimizu
  * @author Jens Schauder
  * @author Oliver Gierke
- * @see EnableJdbcAuditing
  */
 @RequiredArgsConstructor
-public class RelationalAuditingEventListener implements ApplicationListener<BeforeSaveEvent> {
+public class RelationalAuditingEventListener implements ApplicationListener<BeforeSaveEvent>, Ordered {
+
+	/**
+	 * The order used for this {@link org.springframework.context.event.EventListener}. This ensures that it will run
+	 * before other listeners without a specified priority.
+	 *
+	 * @see org.springframework.core.annotation.Order
+	 * @see Ordered
+	 */
+	public static final int AUDITING_ORDER = 100;
 
 	private final IsNewAwareAuditingHandler handler;
 
@@ -44,5 +53,10 @@ public class RelationalAuditingEventListener implements ApplicationListener<Befo
 	@Override
 	public void onApplicationEvent(BeforeSaveEvent event) {
 		handler.markAudited(event.getEntity());
+	}
+
+	@Override
+	public int getOrder() {
+		return AUDITING_ORDER;
 	}
 }


### PR DESCRIPTION
When an event listener is used to set an id before saving it, this ensures the auditing happens before setting the id.
If this is not ensured the auditing listener doesn't consider the entity as new and doesn't set created date and created by user.

See: https://jira.spring.io/browse/DATAJDBC-390