### PR TITLE
DATAJDBC-395 - AbstractJdbcConfiguration no longer registers a bean of type DataAccessStrategy.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>1.1.0.BUILD-SNAPSHOT</version>
+	<version>1.1.0.DATAJDBC-395-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>1.1.0.BUILD-SNAPSHOT</version>
+		<version>1.1.0.DATAJDBC-395-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>1.1.0.BUILD-SNAPSHOT</version>
+	<version>1.1.0.DATAJDBC-395-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>1.1.0.BUILD-SNAPSHOT</version>
+		<version>1.1.0.DATAJDBC-395-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/AbstractJdbcConfiguration.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/AbstractJdbcConfiguration.java
@@ -82,18 +82,12 @@ public abstract class AbstractJdbcConfiguration {
 			ObjectProvider<RelationResolver> relationResolverProvider, Optional<NamingStrategy> namingStrategy,
 			JdbcConverter jdbcConverter) {
 
-		RelationResolver relationResolver = relationResolverProvider.getIfAvailable(() -> dataAccessStrategy( //
-				operations, //
-				jdbcConverter, //
-				jdbcMappingContext(namingStrategy)) //
-		);
+		RelationResolver relationResolver = relationResolverProvider
+				.getIfAvailable(() -> dataAccessStrategy(operations, jdbcConverter, jdbcMappingContext(namingStrategy)));
 
-		return new BasicJdbcConverter( //
-				mappingContext, //
-				relationResolver, //
-				jdbcCustomConversions(), //
-				new DefaultJdbcTypeFactory(operations.getJdbcOperations()) //
-		);
+		DefaultJdbcTypeFactory jdbcTypeFactory = new DefaultJdbcTypeFactory(operations.getJdbcOperations());
+
+		return new BasicJdbcConverter(mappingContext, relationResolver, jdbcCustomConversions(), jdbcTypeFactory);
 	}
 
 	/**
@@ -124,18 +118,10 @@ public abstract class AbstractJdbcConfiguration {
 			ObjectProvider<DataAccessStrategy> dataAccessStrategyProvider, NamedParameterJdbcOperations operations,
 			Optional<NamingStrategy> namingStrategy, @Lazy JdbcConverter jdbcConverter) {
 
-		DataAccessStrategy dataAccessStrategy = dataAccessStrategyProvider.getIfAvailable(() -> dataAccessStrategy( //
-				operations, //
-				jdbcConverter, //
-				jdbcMappingContext(namingStrategy)) //
-		);
+		DataAccessStrategy dataAccessStrategy = dataAccessStrategyProvider //
+				.getIfAvailable(() -> dataAccessStrategy(operations, jdbcConverter, jdbcMappingContext(namingStrategy)));
 
-		return new JdbcAggregateTemplate( //
-				publisher, //
-				context, //
-				converter, //
-				dataAccessStrategy //
-		);
+		return new JdbcAggregateTemplate(publisher, context, converter, dataAccessStrategy);
 	}
 
 	/**
@@ -151,12 +137,8 @@ public abstract class AbstractJdbcConfiguration {
 
 		if (defaultDataAccessStrategy == null) {
 
-			defaultDataAccessStrategy = new DefaultDataAccessStrategy( //
-					new SqlGeneratorSource(context), //
-					context, //
-					jdbcConverter, //
-					operations //
-			);
+			defaultDataAccessStrategy = //
+					new DefaultDataAccessStrategy(new SqlGeneratorSource(context), context, jdbcConverter, operations);
 		}
 		return defaultDataAccessStrategy;
 	}

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>1.1.0.BUILD-SNAPSHOT</version>
+	<version>1.1.0.DATAJDBC-395-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>1.1.0.BUILD-SNAPSHOT</version>
+		<version>1.1.0.DATAJDBC-395-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/src/main/asciidoc/jdbc.adoc
+++ b/src/main/asciidoc/jdbc.adoc
@@ -153,16 +153,16 @@ References between those should be encoded as simple `id` values, which should m
 [[jdbc.entity-persistence.custom-converters]]
 === Custom converters
 
-Custom converters can be registered, for types that are not supported by default, by inheriting your configuration from `JdbcConfiguration` and overwriting the method `jdbcCustomConversions()`.
+Custom converters can be registered, for types that are not supported by default, by inheriting your configuration from `AbstractJdbcConfiguration` and overwriting the method `jdbcCustomConversions()`.
 
 ====
 [source, java]
 ----
 @Configuration
-public class DataJdbcConfiguration extends JdbcConfiguration {
+public class DataJdbcConfiguration extends AbstractJdbcConfiguration {
 
     @Override
-    protected JdbcCustomConversions jdbcCustomConversions() {
+    public JdbcCustomConversions jdbcCustomConversions() {
 
       return new JdbcCustomConversions(Collections.singletonList(TimestampTzToDateConverter.INSTANCE));
 


### PR DESCRIPTION
This avoids having multiple beans of that type in an ApplicationContext when a custom DataAccessStrategy needs to be provided.