### PR TITLE
DATAJDBC-428 Fix BasicJdbcConverter readValue for EntityRowMapper supports Immutable entity AggregateReference field

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/BasicJdbcConverter.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/BasicJdbcConverter.java
@@ -57,6 +57,7 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @author Jens Schauder
  * @author Christoph Strobl
+ * @author Myeonghyeon Lee
  * @since 1.1
  * @see MappingContext
  * @see SimpleTypeHolder
@@ -130,6 +131,9 @@ public class BasicJdbcConverter extends BasicRelationalConverter implements Jdbc
 		}
 
 		if (AggregateReference.class.isAssignableFrom(type.getType())) {
+			if (type.getType().isAssignableFrom(value.getClass())) {
+				return value;
+			}
 
 			return readAggregateReference(value, type);
 		}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/AggregateReference.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/AggregateReference.java
@@ -15,7 +15,9 @@
  */
 package org.springframework.data.jdbc.core.mapping;
 
+import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
 import org.springframework.lang.Nullable;
 
@@ -25,6 +27,7 @@ import org.springframework.lang.Nullable;
  * @param <T> the type of the referenced aggregate root.
  * @param <ID> the type of the id of the referenced aggregate root.
  * @author Jens Schauder
+ * @author Myeonghyeon Lee
  * @since 1.0
  */
 public interface AggregateReference<T, ID> {
@@ -47,6 +50,8 @@ public interface AggregateReference<T, ID> {
 	 * @param <ID>
 	 */
 	@RequiredArgsConstructor
+	@EqualsAndHashCode
+	@ToString
 	class IdOnlyAggregateReference<T, ID> implements AggregateReference<T, ID> {
 
 		private final ID id;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/mapping/IdOnlyAggregateReferenceTest.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/mapping/IdOnlyAggregateReferenceTest.java
@@ -1,0 +1,40 @@
+package org.springframework.data.jdbc.core.mapping;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+import org.springframework.data.jdbc.core.mapping.AggregateReference.IdOnlyAggregateReference;
+
+/**
+ * Unit tests for the {@link IdOnlyAggregateReference}.
+ *
+ * @author Myeonghyeon Lee
+ */
+public class IdOnlyAggregateReferenceTest {
+    @Test   // DATAJDBC-427
+    public void equals() {
+        AggregateReference<DummyEntity, String> reference1 = AggregateReference.to("1");
+        AggregateReference<DummyEntity, String> reference2 = AggregateReference.to("1");
+        assertThat(reference1.equals(reference2)).isTrue();
+        assertThat(reference2.equals(reference1)).isTrue();
+    }
+
+    @Test   // DATAJDBC-427
+    public void equalsFalse() {
+        AggregateReference<DummyEntity, String> reference1 = AggregateReference.to("1");
+        AggregateReference<DummyEntity, String> reference2 = AggregateReference.to("2");
+        assertThat(reference1.equals(reference2)).isFalse();
+        assertThat(reference2.equals(reference1)).isFalse();
+    }
+
+    @Test   // DATAJDBC-427
+    public void hashCodeTest() {
+        AggregateReference<DummyEntity, String> reference1 = AggregateReference.to("1");
+        AggregateReference<DummyEntity, String> reference2 = AggregateReference.to("1");
+        assertThat(reference1.hashCode()).isEqualTo(reference2.hashCode());
+    }
+
+    private static class DummyEntity {
+        private String id;
+    }
+}

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/conversion/AggregateChangeUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/conversion/AggregateChangeUnitTests.java
@@ -41,12 +41,15 @@ public class AggregateChangeUnitTests {
 
 	DummyEntity entity = new DummyEntity();
 	Content content = new Content();
+	Tag tag = new Tag();
 
 	RelationalMappingContext context = new RelationalMappingContext();
 	RelationalConverter converter = new BasicRelationalConverter(context);
 
 	PersistentPropertyAccessor<DummyEntity> propertyAccessor = context.getRequiredPersistentEntity(DummyEntity.class)
 			.getPropertyAccessor(entity);
+	PersistentPropertyAccessor<Content> contentPropertyAccessor = context.getRequiredPersistentEntity(Content.class)
+		.getPropertyAccessor(content);
 	Object id = 23;
 
 	DbAction.WithEntity<?> rootInsert = new DbAction.InsertRoot<>(entity);
@@ -57,6 +60,12 @@ public class AggregateChangeUnitTests {
 				context.getPersistentPropertyPath(propertyName, DummyEntity.class), rootInsert);
 		insert.getQualifiers().put(toPath(propertyName, DummyEntity.class), key);
 
+		return insert;
+	}
+
+	DbAction.Insert<?> createDeepInsert(String propertyName, Object value, Object key, DbAction.Insert<?> parentInsert) {
+		DbAction.Insert<Object> insert = new DbAction.Insert<>(value, toPath(entity, value), parentInsert);
+		insert.getQualifiers().put(toPath(parentInsert.getPropertyPath().toDotPath() + "." + propertyName, DummyEntity.class), key);
 		return insert;
 	}
 
@@ -115,12 +124,114 @@ public class AggregateChangeUnitTests {
 				.containsExactlyInAnyOrder(tuple("one", 23));
 	}
 
+	@Test	// DATAJDBC-291
+	public void setIdForDeepReference() {
+
+		content.single = tag;
+		entity.single = content;
+
+		DbAction.Insert<?> parentInsert = createInsert("single", content, null);
+		DbAction.Insert<?> insert = createDeepInsert("single", tag, null, parentInsert);
+
+		AggregateChange.setIdOfNonRootEntity(context, converter, propertyAccessor, insert, id);
+
+		Content result = contentPropertyAccessor.getBean();
+
+		assertThat(result.single.id).isEqualTo(id);
+	}
+
+	@Test	// DATAJDBC-291
+	public void setIdForDeepReferenceElementList() {
+
+		content.tagList.add(tag);
+		entity.single = content;
+
+		DbAction.Insert<?> parentInsert = createInsert("single", content, null);
+		DbAction.Insert<?> insert = createDeepInsert("tagList", tag, 0, parentInsert);
+
+		AggregateChange.setIdOfNonRootEntity(context, converter, propertyAccessor, insert, id);
+
+		Content result = contentPropertyAccessor.getBean();
+		assertThat(result.tagList).extracting(c -> c.id).containsExactlyInAnyOrder(23);
+	}
+
+	@Test	// DATAJDBC-291
+	public void setIdForDeepElementSetElementSet() {
+
+		content.tagSet.add(tag);
+		entity.contentSet.add(content);
+
+		DbAction.Insert<?> parentInsert = createInsert("contentSet", content, null);
+		DbAction.Insert<?> insert = createDeepInsert("tagSet", tag, null, parentInsert);
+
+		AggregateChange.setIdOfNonRootEntity(context, converter, propertyAccessor, insert, id);
+
+		Content result = contentPropertyAccessor.getBean();
+		assertThat(result.tagSet).isNotNull();
+		assertThat(result.tagSet).extracting(c -> c == null ? "null" : c.id).containsExactlyInAnyOrder(23);
+	}
+
+	@Test	// DATAJDBC-291
+	public void setIdForDeepElementListSingleReference() {
+
+		content.single = tag;
+		entity.contentList.add(content);
+
+		DbAction.Insert<?> parentInsert = createInsert("contentList", content, 0);
+		DbAction.Insert<?> insert = createDeepInsert("single", tag, null, parentInsert);
+
+		AggregateChange.setIdOfNonRootEntity(context, converter, propertyAccessor, insert, id);
+
+		Content result = contentPropertyAccessor.getBean();
+		assertThat(result.single.id).isEqualTo(id);
+	}
+
+	@Test	// DATAJDBC-291
+	public void setIdForDeepElementListElementList() {
+
+		content.tagList.add(tag);
+		entity.contentList.add(content);
+
+		DbAction.Insert<?> parentInsert = createInsert("contentList", content, 0);
+		DbAction.Insert<?> insert = createDeepInsert("tagList", tag, 0, parentInsert);
+
+		AggregateChange.setIdOfNonRootEntity(context, converter, propertyAccessor, insert, id);
+
+		Content result = contentPropertyAccessor.getBean();
+		assertThat(result.tagList).extracting(c -> c.id).containsExactlyInAnyOrder(23);
+	}
+
+	@Test	// DATAJDBC-291
+	public void setIdForDeepElementMapElementMap() {
+
+		content.tagMap.put("one", tag);
+		entity.contentMap.put("one", content);
+
+		DbAction.Insert<?> parentInsert = createInsert("contentMap", content, "one");
+		DbAction.Insert<?> insert = createDeepInsert("tagMap", tag, "one", parentInsert);
+
+		AggregateChange.setIdOfNonRootEntity(context, converter, propertyAccessor, insert, id);
+
+		Content result = contentPropertyAccessor.getBean();
+		assertThat(result.tagMap.entrySet()).extracting(e -> e.getKey(), e -> e.getValue().id)
+			.containsExactlyInAnyOrder(tuple("one", 23));
+	}
+
 	PersistentPropertyPath<RelationalPersistentProperty> toPath(String path, Class source) {
 
 		PersistentPropertyPaths<?, RelationalPersistentProperty> persistentPropertyPaths = context
 				.findPersistentPropertyPaths(source, p -> true);
 
 		return persistentPropertyPaths.filter(p -> p.toDotPath().equals(path)).stream().findFirst().orElse(null);
+	}
+
+	PersistentPropertyPath<RelationalPersistentProperty> toPath(DummyEntity root, Object pathValue) {
+		// DefaultPersistentPropertyPath is package-public
+		return new WritingContext(context, entity, new AggregateChange<>(AggregateChange.Kind.SAVE, DummyEntity.class, root))
+			.insert().stream().filter(a -> a instanceof DbAction.Insert).map(DbAction.Insert.class::cast)
+			.filter(a -> a.getEntity() == pathValue)
+			.map(DbAction.Insert::getPropertyPath)
+			.findFirst().orElse(null);
 	}
 
 	private static class DummyEntity {
@@ -138,6 +249,18 @@ public class AggregateChangeUnitTests {
 
 	private static class Content {
 
+		@Id Integer id;
+
+		Tag single;
+
+		Set<Tag> tagSet = new HashSet<>();
+
+		List<Tag> tagList = new ArrayList<>();
+
+		Map<String, Tag> tagMap = new HashMap<>();
+	}
+
+	private static class Tag {
 		@Id Integer id;
 	}
 }


### PR DESCRIPTION
[DATAJDBC-428](https://jira.spring.io/browse/DATAJDBC-428?jql=text%20~%20%22AggregateReference%22): EntityRowMapper can not extract AggregateReference field for immutable entity
[DATAJDBC-427](https://jira.spring.io/browse/DATAJDBC-427?jql=text%20~%20%22AggregateReference%22): Implements equalsAndHashCode for AggregateReference