### PR TITLE
DATAJDBC-428 Fix BasicJdbcConverter readValue for EntityRowMapper supports Immutable entity AggregateReference field

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/BasicJdbcConverter.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/BasicJdbcConverter.java
@@ -57,6 +57,7 @@ import org.springframework.util.Assert;
  * @author Mark Paluch
  * @author Jens Schauder
  * @author Christoph Strobl
+ * @author Myeonghyeon Lee
  * @since 1.1
  * @see MappingContext
  * @see SimpleTypeHolder
@@ -130,6 +131,9 @@ public class BasicJdbcConverter extends BasicRelationalConverter implements Jdbc
 		}
 
 		if (AggregateReference.class.isAssignableFrom(type.getType())) {
+			if (type.getType().isAssignableFrom(value.getClass())) {
+				return value;
+			}
 
 			return readAggregateReference(value, type);
 		}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/AggregateReference.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/AggregateReference.java
@@ -15,7 +15,9 @@
  */
 package org.springframework.data.jdbc.core.mapping;
 
+import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
+import lombok.ToString;
 
 import org.springframework.lang.Nullable;
 
@@ -25,6 +27,7 @@ import org.springframework.lang.Nullable;
  * @param <T> the type of the referenced aggregate root.
  * @param <ID> the type of the id of the referenced aggregate root.
  * @author Jens Schauder
+ * @author Myeonghyeon Lee
  * @since 1.0
  */
 public interface AggregateReference<T, ID> {
@@ -47,6 +50,8 @@ public interface AggregateReference<T, ID> {
 	 * @param <ID>
 	 */
 	@RequiredArgsConstructor
+	@EqualsAndHashCode
+	@ToString
 	class IdOnlyAggregateReference<T, ID> implements AggregateReference<T, ID> {
 
 		private final ID id;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/EntityRowMapperUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/EntityRowMapperUnitTests.java
@@ -51,6 +51,7 @@ import org.mockito.stubbing.Answer;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.PersistenceConstructor;
+import org.springframework.data.jdbc.core.mapping.AggregateReference;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.relational.core.mapping.Embedded;
@@ -71,6 +72,7 @@ import org.springframework.util.Assert;
  * @author Maciej Walkowiak
  * @author Bastian Wilhelm
  * @author Christoph Strobl
+ * @author Myeonghyeon Lee
  */
 public class EntityRowMapperUnitTests {
 
@@ -129,6 +131,21 @@ public class EntityRowMapperUnitTests {
 				.containsExactly(ID_FOR_ENTITY_NOT_REFERENCING_MAP, "alpha");
 	}
 
+	@Test   // DATAJDBC-427
+	public void simpleWithReferenceGetProperlyExtracted() throws SQLException {
+
+		ResultSet rs = mockResultSet(asList("id", "name", "trivial_id"), //
+			ID_FOR_ENTITY_NOT_REFERENCING_MAP, "alpha", 100L);
+		rs.next();
+
+		WithReference extracted = createRowMapper(WithReference.class).mapRow(rs, 1);
+
+		assertThat(extracted) //
+			.isNotNull() //
+			.extracting(e -> e.id, e -> e.name, e -> e.trivialId) //
+			.containsExactly(ID_FOR_ENTITY_NOT_REFERENCING_MAP, "alpha", AggregateReference.to(100L));
+	}
+
 	@Test // DATAJDBC-113
 	public void simpleOneToOneGetsProperlyExtracted() throws SQLException {
 
@@ -157,6 +174,21 @@ public class EntityRowMapperUnitTests {
 				.isNotNull() //
 				.extracting(e -> e.id, e -> e.name, e -> e.child.id, e -> e.child.name) //
 				.containsExactly(ID_FOR_ENTITY_NOT_REFERENCING_MAP, "alpha", 24L, "beta");
+	}
+
+	@Test   // DATAJDBC-427
+	public void immutableWithReferenceGetsProperlyExtracted() throws SQLException {
+
+		ResultSet rs = mockResultSet(asList("id", "name", "trivial_id"), //
+			ID_FOR_ENTITY_NOT_REFERENCING_MAP, "alpha", 100L);
+		rs.next();
+
+		WithReferenceImmutable extracted = createRowMapper(WithReferenceImmutable.class).mapRow(rs, 1);
+
+		assertThat(extracted) //
+			.isNotNull() //
+			.extracting(e -> e.id, e -> e.name, e -> e.trivialId) //
+			.containsExactly(ID_FOR_ENTITY_NOT_REFERENCING_MAP, "alpha", AggregateReference.to(100L));
 	}
 
 	// TODO add additional test for multilevel embeddables
@@ -438,6 +470,26 @@ public class EntityRowMapperUnitTests {
 
 		@Id Long id;
 		String name;
+	}
+
+	@EqualsAndHashCode
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Getter
+	static class WithReference {
+
+		@Id Long id;
+		String name;
+		AggregateReference<Trivial, Long> trivialId;
+	}
+
+	@Wither
+	@RequiredArgsConstructor
+	static class WithReferenceImmutable {
+
+		@Id private final Long id;
+		private final String name;
+		private final AggregateReference<TrivialImmutable, Long> trivialId;
 	}
 
 	static class OneToOne {

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/mapping/IdOnlyAggregateReferenceTest.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/mapping/IdOnlyAggregateReferenceTest.java
@@ -1,0 +1,40 @@
+package org.springframework.data.jdbc.core.mapping;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.Test;
+import org.springframework.data.jdbc.core.mapping.AggregateReference.IdOnlyAggregateReference;
+
+/**
+ * Unit tests for the {@link IdOnlyAggregateReference}.
+ *
+ * @author Myeonghyeon Lee
+ */
+public class IdOnlyAggregateReferenceTest {
+    @Test   // DATAJDBC-427
+    public void equals() {
+        AggregateReference<DummyEntity, String> reference1 = AggregateReference.to("1");
+        AggregateReference<DummyEntity, String> reference2 = AggregateReference.to("1");
+        assertThat(reference1.equals(reference2)).isTrue();
+        assertThat(reference2.equals(reference1)).isTrue();
+    }
+
+    @Test   // DATAJDBC-427
+    public void equalsFalse() {
+        AggregateReference<DummyEntity, String> reference1 = AggregateReference.to("1");
+        AggregateReference<DummyEntity, String> reference2 = AggregateReference.to("2");
+        assertThat(reference1.equals(reference2)).isFalse();
+        assertThat(reference2.equals(reference1)).isFalse();
+    }
+
+    @Test   // DATAJDBC-427
+    public void hashCodeTest() {
+        AggregateReference<DummyEntity, String> reference1 = AggregateReference.to("1");
+        AggregateReference<DummyEntity, String> reference2 = AggregateReference.to("1");
+        assertThat(reference1.hashCode()).isEqualTo(reference2.hashCode());
+    }
+
+    private static class DummyEntity {
+        private String id;
+    }
+}


### PR DESCRIPTION
[DATAJDBC-428](https://jira.spring.io/browse/DATAJDBC-428?jql=text%20~%20%22AggregateReference%22): EntityRowMapper can not extract AggregateReference field for immutable entity
[DATAJDBC-427](https://jira.spring.io/browse/DATAJDBC-427?jql=text%20~%20%22AggregateReference%22): Implements equalsAndHashCode for AggregateReference