### PR TITLE
Create CONTRIBUTING.adoc

### DIFF
--- a/CONTRIBUTING.adoc
+++ b/CONTRIBUTING.adoc
@@ -1,0 +1,3 @@
+= Spring Data contribution guidelines
+
+You find the contribution guidelines for Spring Data projects https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc[here].


### PR DESCRIPTION
The CONTRIBUTING.adoc link is broken as the file is missing on this repository. I used the same pattern I found on spring-data-commons.