### PR TITLE
DATAJDBC-437 - In strict mode we only claim repositories for domain types with `@Table` annotation.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>1.2.0.BUILD-SNAPSHOT</version>
+	<version>1.2.0.DATAJDBC-437-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>1.2.0.BUILD-SNAPSHOT</version>
+		<version>1.2.0.DATAJDBC-437-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>1.2.0.BUILD-SNAPSHOT</version>
+	<version>1.2.0.DATAJDBC-437-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>1.2.0.BUILD-SNAPSHOT</version>
+		<version>1.2.0.DATAJDBC-437-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/JdbcRepositoryConfigExtension.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/JdbcRepositoryConfigExtension.java
@@ -15,10 +15,14 @@
  */
 package org.springframework.data.jdbc.repository.config;
 
+import java.lang.annotation.Annotation;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Locale;
 
 import org.springframework.beans.factory.support.BeanDefinitionBuilder;
 import org.springframework.data.jdbc.repository.support.JdbcRepositoryFactoryBean;
+import org.springframework.data.relational.core.mapping.Table;
 import org.springframework.data.repository.config.RepositoryConfigurationExtensionSupport;
 import org.springframework.data.repository.config.RepositoryConfigurationSource;
 import org.springframework.util.StringUtils;
@@ -74,5 +78,13 @@ public class JdbcRepositoryConfigExtension extends RepositoryConfigurationExtens
 		source.getAttribute("dataAccessStrategyRef") //
 				.filter(StringUtils::hasText) //
 				.ifPresent(s -> builder.addPropertyReference("dataAccessStrategy", s));
+	}
+
+	/**
+	 * In strict mode only domain types having a {@link Table} annotation get a repository.
+	 */
+	@Override
+	protected Collection<Class<? extends Annotation>> getIdentifyingAnnotations() {
+		return Collections.singleton(Table.class);
 	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactory.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/support/JdbcRepositoryFactory.java
@@ -120,7 +120,7 @@ public class JdbcRepositoryFactory extends RepositoryFactorySupport {
 		JdbcAggregateTemplate template = new JdbcAggregateTemplate(publisher, context, converter, accessStrategy);
 
 		SimpleJdbcRepository<?, Object> repository = new SimpleJdbcRepository<>(template,
-				context.getPersistentEntity(repositoryInformation.getDomainType()));
+				context.getRequiredPersistentEntity(repositoryInformation.getDomainType()));
 
 		if (entityCallbacks != null) {
 			template.setEntityCallbacks(entityCallbacks);

--- a/spring-data-jdbc/src/main/resources/META-INF/spring.factories
+++ b/spring-data-jdbc/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,1 @@
+org.springframework.data.repository.core.support.RepositoryFactorySupport=org.springframework.data.jdbc.repository.support.JdbcRepositoryFactory

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCrossAggregateHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCrossAggregateHsqlIntegrationTests.java
@@ -22,9 +22,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.core.mapping.AggregateReference;
@@ -58,8 +56,7 @@ public class JdbcRepositoryCrossAggregateHsqlIntegrationTests {
 
 	@Configuration
 	@Import(TestConfiguration.class)
-	@EnableJdbcRepositories(includeFilters = @Filter(type = FilterType.REGEX,
-			pattern = ".*\\.JdbcRepositoryCrossAggregateHsqlIntegrationTests\\$.*"), considerNestedRepositories = true)
+	@EnableJdbcRepositories(considerNestedRepositories = true)
 	static class Config {
 
 		@Autowired JdbcRepositoryFactory factory;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCrossAggregateHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCrossAggregateHsqlIntegrationTests.java
@@ -15,14 +15,16 @@
  */
 package org.springframework.data.jdbc.repository;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.core.mapping.AggregateReference;
@@ -56,7 +58,8 @@ public class JdbcRepositoryCrossAggregateHsqlIntegrationTests {
 
 	@Configuration
 	@Import(TestConfiguration.class)
-	@EnableJdbcRepositories(considerNestedRepositories = true)
+	@EnableJdbcRepositories(includeFilters = @Filter(type = FilterType.REGEX,
+			pattern = ".*\\.JdbcRepositoryCrossAggregateHsqlIntegrationTests\\$.*"), considerNestedRepositories = true)
 	static class Config {
 
 		@Autowired JdbcRepositoryFactory factory;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryIdGenerationIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryIdGenerationIntegrationTests.java
@@ -31,6 +31,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
@@ -145,7 +146,8 @@ public class JdbcRepositoryIdGenerationIntegrationTests {
 
 	@Configuration
 	@ComponentScan("org.springframework.data.jdbc.testing")
-	@EnableJdbcRepositories(considerNestedRepositories = true)
+	@EnableJdbcRepositories(includeFilters = @ComponentScan.Filter(type = FilterType.REGEX,
+			pattern = ".*\\.JdbcRepositoryIdGenerationIntegrationTests\\$.*"), considerNestedRepositories = true)
 	static class TestConfiguration {
 
 		AtomicLong lastId = new AtomicLong(0);

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryIdGenerationIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryIdGenerationIntegrationTests.java
@@ -146,8 +146,7 @@ public class JdbcRepositoryIdGenerationIntegrationTests {
 
 	@Configuration
 	@ComponentScan("org.springframework.data.jdbc.testing")
-	@EnableJdbcRepositories(includeFilters = @ComponentScan.Filter(type = FilterType.REGEX,
-			pattern = ".*\\.JdbcRepositoryIdGenerationIntegrationTests\\$.*"), considerNestedRepositories = true)
+	@EnableJdbcRepositories(considerNestedRepositories = true)
 	static class TestConfiguration {
 
 		AtomicLong lastId = new AtomicLong(0);

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryManipulateDbActionsIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryManipulateDbActionsIntegrationTests.java
@@ -187,8 +187,7 @@ public class JdbcRepositoryManipulateDbActionsIntegrationTests {
 
 	@Configuration
 	@Import(TestConfiguration.class)
-	@EnableJdbcRepositories(includeFilters = @ComponentScan.Filter(type = FilterType.REGEX,
-			pattern = ".*\\.JdbcRepositoryManipulateDbActionsIntegrationTests\\$.*"), considerNestedRepositories = true)
+	@EnableJdbcRepositories(considerNestedRepositories = true)
 	static class Config {
 
 		static long lastLogId;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryManipulateDbActionsIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryManipulateDbActionsIntegrationTests.java
@@ -33,7 +33,9 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationListener;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.PersistenceConstructor;
@@ -185,7 +187,8 @@ public class JdbcRepositoryManipulateDbActionsIntegrationTests {
 
 	@Configuration
 	@Import(TestConfiguration.class)
-	@EnableJdbcRepositories(considerNestedRepositories = true)
+	@EnableJdbcRepositories(includeFilters = @ComponentScan.Filter(type = FilterType.REGEX,
+			pattern = ".*\\.JdbcRepositoryManipulateDbActionsIntegrationTests\\$.*"), considerNestedRepositories = true)
 	static class Config {
 
 		static long lastLogId;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryQueryMappingConfigurationIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryQueryMappingConfigurationIntegrationTests.java
@@ -30,9 +30,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.annotation.Id;
@@ -61,10 +59,7 @@ public class JdbcRepositoryQueryMappingConfigurationIntegrationTests {
 
 	@Configuration
 	@Import(TestConfiguration.class)
-	@EnableJdbcRepositories(
-			includeFilters = @ComponentScan.Filter(type = FilterType.REGEX,
-					pattern = ".*\\.JdbcRepositoryQueryMappingConfigurationIntegrationTests\\$.*"),
-			considerNestedRepositories = true)
+	@EnableJdbcRepositories(considerNestedRepositories = true)
 	static class Config {
 
 		@Bean

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/EnableJdbcAuditingHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/EnableJdbcAuditingHsqlIntegrationTests.java
@@ -33,6 +33,8 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.ComponentScan.Filter;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -258,7 +260,9 @@ public class EnableJdbcAuditingHsqlIntegrationTests {
 	}
 
 	@ComponentScan("org.springframework.data.jdbc.testing")
-	@EnableJdbcRepositories(considerNestedRepositories = true)
+	@EnableJdbcRepositories(
+			includeFilters = @Filter(type = FilterType.REGEX, pattern = ".*\\.EnableJdbcAuditingHsqlIntegrationTests\\$.*"),
+			considerNestedRepositories = true)
 	static class TestConfiguration {
 
 		@Bean

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/EnableJdbcAuditingHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/EnableJdbcAuditingHsqlIntegrationTests.java
@@ -33,8 +33,6 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
-import org.springframework.context.annotation.ComponentScan.Filter;
-import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
@@ -260,9 +258,7 @@ public class EnableJdbcAuditingHsqlIntegrationTests {
 	}
 
 	@ComponentScan("org.springframework.data.jdbc.testing")
-	@EnableJdbcRepositories(
-			includeFilters = @Filter(type = FilterType.REGEX, pattern = ".*\\.EnableJdbcAuditingHsqlIntegrationTests\\$.*"),
-			considerNestedRepositories = true)
+	@EnableJdbcRepositories(considerNestedRepositories = true)
 	static class TestConfiguration {
 
 		@Bean

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/JdbcRepositoryConfigExtensionUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/JdbcRepositoryConfigExtensionUnitTests.java
@@ -37,7 +37,6 @@ import org.springframework.data.repository.config.RepositoryConfigurationSource;
  * Unit tests for {@link JdbcRepositoryConfigExtension}.
  *
  * @author Jens Schauder
- * @since 1.2
  */
 public class JdbcRepositoryConfigExtensionUnitTests {
 
@@ -54,9 +53,11 @@ public class JdbcRepositoryConfigExtensionUnitTests {
 
 		JdbcRepositoryConfigExtension extension = new JdbcRepositoryConfigExtension();
 
-		Collection<RepositoryConfiguration<RepositoryConfigurationSource>> configs = extension.getRepositoryConfigurations(configurationSource, loader, true);
+		Collection<RepositoryConfiguration<RepositoryConfigurationSource>> configs = extension
+				.getRepositoryConfigurations(configurationSource, loader, true);
 
-		assertThat(configs).extracting(config -> config.getRepositoryInterface()).containsExactly(SampleRepository.class.getName());
+		assertThat(configs).extracting(config -> config.getRepositoryInterface())
+				.containsExactly(SampleRepository.class.getName());
 	}
 
 	@EnableJdbcRepositories(considerNestedRepositories = true)
@@ -69,5 +70,7 @@ public class JdbcRepositoryConfigExtensionUnitTests {
 
 	interface SampleRepository extends Repository<Sample, Long> {}
 
-	interface UnannotatedRepository extends Repository<Object, Long> {}
+	static class Unannotated {}
+
+	interface UnannotatedRepository extends Repository<Unannotated, Long> {}
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/JdbcRepositoryConfigExtensionUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/config/JdbcRepositoryConfigExtensionUnitTests.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jdbc.repository.config;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Collection;
+
+import org.junit.Test;
+import org.springframework.beans.factory.support.BeanDefinitionRegistry;
+import org.springframework.beans.factory.support.DefaultListableBeanFactory;
+import org.springframework.core.env.Environment;
+import org.springframework.core.env.StandardEnvironment;
+import org.springframework.core.io.ResourceLoader;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+import org.springframework.core.type.StandardAnnotationMetadata;
+import org.springframework.data.relational.core.mapping.Table;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.config.AnnotationRepositoryConfigurationSource;
+import org.springframework.data.repository.config.RepositoryConfiguration;
+import org.springframework.data.repository.config.RepositoryConfigurationSource;
+
+/**
+ * Unit tests for {@link JdbcRepositoryConfigExtension}.
+ *
+ * @author Jens Schauder
+ * @since 1.2
+ */
+public class JdbcRepositoryConfigExtensionUnitTests {
+
+	StandardAnnotationMetadata metadata = new StandardAnnotationMetadata(Config.class, true);
+	ResourceLoader loader = new PathMatchingResourcePatternResolver();
+	Environment environment = new StandardEnvironment();
+	BeanDefinitionRegistry registry = new DefaultListableBeanFactory();
+
+	RepositoryConfigurationSource configurationSource = new AnnotationRepositoryConfigurationSource(metadata,
+			EnableJdbcRepositories.class, loader, environment, registry);
+
+	@Test // DATAJPA-437
+	public void isStrictMatchOnlyIfDomainTypeIsAnnotatedWithDocument() {
+
+		JdbcRepositoryConfigExtension extension = new JdbcRepositoryConfigExtension();
+
+		Collection<RepositoryConfiguration<RepositoryConfigurationSource>> configs = extension.getRepositoryConfigurations(configurationSource, loader, true);
+
+		assertThat(configs).extracting(config -> config.getRepositoryInterface()).containsExactly(SampleRepository.class.getName());
+	}
+
+	@EnableJdbcRepositories(considerNestedRepositories = true)
+	static class Config {
+
+	}
+
+	@Table
+	static class Sample {}
+
+	interface SampleRepository extends Repository<Sample, Long> {}
+
+	interface UnannotatedRepository extends Repository<Object, Long> {}
+}

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>1.2.0.BUILD-SNAPSHOT</version>
+	<version>1.2.0.DATAJDBC-437-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -13,7 +13,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>1.2.0.BUILD-SNAPSHOT</version>
+		<version>1.2.0.DATAJDBC-437-SNAPSHOT</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
Before this change Spring Data JDBC didn't specify any identifying annotation and therefore would claim all or no repository depending on the the version of Spring Data Commons.

Also added the RepositoryFactorySupport to spring.factory in order to support detection of multiple RepositoryFactorySupport implementations on the classpath.

See also: https://jira.spring.io/browse/DATACMNS-1596.

Original issue: https://jira.spring.io/browse/DATAJDBC-437.