### PR TITLE
DATAJDBC-438 throw exception and fail if Aggregate update row zero

### DIFF
--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/DefaultJdbcInterpreterUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/DefaultJdbcInterpreterUnitTests.java
@@ -25,12 +25,14 @@ import java.util.List;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import org.springframework.dao.TransientDataAccessResourceException;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.relational.core.conversion.DbAction.Insert;
 import org.springframework.data.relational.core.conversion.DbAction.InsertRoot;
+import org.springframework.data.relational.core.conversion.DbAction.UpdateRoot;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 import org.springframework.data.relational.domain.Identifier;
@@ -40,6 +42,7 @@ import org.springframework.data.relational.domain.Identifier;
  *
  * @author Jens Schauder
  * @author Mark Paluch
+ * @author Myeonghyeon Lee
  */
 public class DefaultJdbcInterpreterUnitTests {
 
@@ -151,6 +154,15 @@ public class DefaultJdbcInterpreterUnitTests {
 						tuple("root_with_list_key", 3, Integer.class), // midlevel key
 						tuple("with_list_key", 6, Integer.class) // lowlevel key
 				);
+	}
+
+	@Test(expected = TransientDataAccessResourceException.class) // DATAJDBC-438
+	public void throwExceptionUpdateFailedRootDoesNotExist() {
+		container.id = CONTAINER_ID;
+		UpdateRoot<Container> containerUpdate = new UpdateRoot<>(container);
+		when(dataAccessStrategy.update(container, Container.class)).thenReturn(false);
+
+		interpreter.interpret(containerUpdate);
 	}
 
 	@SuppressWarnings("unused")

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateTemplateIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/JdbcAggregateTemplateIntegrationTests.java
@@ -48,6 +48,7 @@ import org.springframework.data.jdbc.core.convert.DataAccessStrategy;
 import org.springframework.data.jdbc.testing.DatabaseProfileValueSource;
 import org.springframework.data.jdbc.testing.HsqlDbOnly;
 import org.springframework.data.jdbc.testing.TestConfiguration;
+import org.springframework.data.relational.core.conversion.DbActionExecutionException;
 import org.springframework.data.relational.core.conversion.RelationalConverter;
 import org.springframework.data.relational.core.mapping.Column;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
@@ -67,6 +68,7 @@ import org.springframework.transaction.annotation.Transactional;
  * @author Jens Schauder
  * @author Thomas Lang
  * @author Mark Paluch
+ * @author Myeonghyeon Lee
  */
 @ContextConfiguration
 @Transactional
@@ -201,6 +203,14 @@ public class JdbcAggregateTemplateIntegrationTests {
 		softly.assertThat(template.findAll(Manual.class)).describedAs("Manuals failed to delete").isEmpty();
 
 		softly.assertAll();
+	}
+
+	@Test(expected = DbActionExecutionException.class)  // DATAJDBC-438
+	public void updateFailedRootDoesNotExist() {
+		LegoSet entity = new LegoSet();
+		entity.setId(100L);	// not exist
+
+		template.save(entity);
 	}
 
 	@Test // DATAJDBC-112

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/SimpleJdbcRepositoryEventsUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/SimpleJdbcRepositoryEventsUnitTests.java
@@ -65,6 +65,7 @@ import org.springframework.jdbc.support.KeyHolder;
  * @author Jens Schauder
  * @author Mark Paluch
  * @author Oliver Gierke
+ * @author Myeonghyeon Lee
  */
 public class SimpleJdbcRepositoryEventsUnitTests {
 
@@ -85,6 +86,8 @@ public class SimpleJdbcRepositoryEventsUnitTests {
 
 		this.dataAccessStrategy = spy(new DefaultDataAccessStrategy(generatorSource, context, converter, operations));
 		delegatingDataAccessStrategy.setDelegate(dataAccessStrategy);
+
+		doReturn(true).when(dataAccessStrategy).update(any(), any());
 
 		JdbcRepositoryFactory factory = new JdbcRepositoryFactory(dataAccessStrategy, context, converter, publisher,
 				operations);


### PR DESCRIPTION
[DATAJDBC-438 Saving a record with an id that doesn't exist should return an error/warning to caller](https://jira.spring.io/projects/DATAJDBC/issues/DATAJDBC-438?filter=allopenissues)

When saving an Aggregate with an ID in the Repository, if the update row is 0, a TransientDataAccessResourceException is thrown.

