### PR TITLE
DATAJDBC-444 Add getColumnAlias for RelationalPersistentProperty

### DIFF
--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
@@ -44,6 +44,7 @@ import org.springframework.util.StringUtils;
  * @author Greg Turnquist
  * @author Florian Lüdiger
  * @author Bastian Wilhelm
+ * @author Myeonghyeon Lee
  */
 public class BasicRelationalPersistentProperty extends AnnotationBasedPersistentProperty<RelationalPersistentProperty>
 		implements RelationalPersistentProperty {
@@ -127,6 +128,11 @@ public class BasicRelationalPersistentProperty extends AnnotationBasedPersistent
 	public String getColumnName() {
 		return columnName.get();
 	}
+
+	@Override
+    public String getColumnAlias() {
+	    return getColumnName();
+    }
 
 	/**
 	 * The type to be used to store this property in the database.

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
@@ -123,10 +123,6 @@ public class BasicRelationalPersistentProperty extends AnnotationBasedPersistent
 		return false;
 	}
 
-	/*
-	 * (non-Javadoc)
-	 * @see org.springframework.data.jdbc.core.mapping.model.JdbcPersistentProperty#getColumnName()
-	 */
 	@Override
 	public String getColumnName() {
 		return columnName.get();

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/PersistentPropertyPathExtension.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/PersistentPropertyPathExtension.java
@@ -20,7 +20,6 @@ import lombok.EqualsAndHashCode;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.PersistentPropertyPath;
 import org.springframework.data.mapping.context.MappingContext;
-import org.springframework.data.util.Lazy;
 import org.springframework.lang.Nullable;
 import org.springframework.util.Assert;
 
@@ -29,16 +28,15 @@ import org.springframework.util.Assert;
  * available used in SQL generation and conversion
  *
  * @author Jens Schauder
+ * @author Myeonghyeon Lee
  * @since 1.1
  */
-@EqualsAndHashCode(exclude = { "columnAlias", "context" })
+@EqualsAndHashCode(exclude = { "context" })
 public class PersistentPropertyPathExtension {
 
 	private final RelationalPersistentEntity<?> entity;
 	private final @Nullable PersistentPropertyPath<RelationalPersistentProperty> path;
 	private final MappingContext<RelationalPersistentEntity<?>, RelationalPersistentProperty> context;
-
-	private final Lazy<String> columnAlias = Lazy.of(() -> prefixWithTableAlias(getColumnName()));
 
 	/**
 	 * Creates the empty path referencing the root itself.
@@ -191,7 +189,11 @@ public class PersistentPropertyPathExtension {
 	 * @throws IllegalStateException when called on an empty path.
 	 */
 	public String getColumnAlias() {
-		return columnAlias.get();
+
+		Assert.state(path != null, "Path is null");
+
+		return prefixWithTableAlias(
+			assembleColumnName(path.getRequiredLeafProperty().getColumnAlias()));
 	}
 
 	/**

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/RelationalPersistentProperty.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/RelationalPersistentProperty.java
@@ -24,6 +24,7 @@ import org.springframework.lang.Nullable;
  * @author Jens Schauder
  * @author Oliver Gierke
  * @author Bastian Wilhelm
+ * @author Myeonghyeon Lee
  */
 public interface RelationalPersistentProperty extends PersistentProperty<RelationalPersistentProperty> {
 
@@ -35,6 +36,15 @@ public interface RelationalPersistentProperty extends PersistentProperty<Relatio
 	 * @return the name of the column backing this property.
 	 */
 	String getColumnName();
+
+	/**
+	 * Returns the alias of the column backing this property.
+	 *
+	 * @return the alias of the column backing this property.
+	 */
+	default String getColumnAlias() {
+		return getColumnName();
+	}
 
 	/**
 	 * The type to be used to store this property in the database. Multidimensional arrays are unwrapped to reflect a


### PR DESCRIPTION
- Add getColumnAlias ​​method to RelationalPersistentProperty, and use it in PersistentPropertyPathExtension.
- `getColumnAlias` ​​delegates `getColumnName` as the default method to maintain the same behavior as before.

[DATAJDBC-444](https://jira.spring.io/browse/DATAJDBC-444)