### PR TITLE
DATAJDBC-479 - Use SqlIdentifier in SQL AST

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAJDBC-476-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAJDBC-476-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAJDBC-476-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAJDBC-476-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlContext.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlContext.java
@@ -18,10 +18,8 @@ package org.springframework.data.jdbc.core.convert;
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.sql.Column;
-import org.springframework.data.relational.core.sql.SQL;
-import org.springframework.data.relational.core.sql.Table;
-import org.springframework.data.relational.core.sql.IdentifierProcessing;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
+import org.springframework.data.relational.core.sql.Table;
 
 /**
  * Utility to get from path to SQL DSL elements.
@@ -35,21 +33,19 @@ class SqlContext {
 
 	private final RelationalPersistentEntity<?> entity;
 	private final Table table;
-	private final IdentifierProcessing identifierProcessing;
 
-	SqlContext(RelationalPersistentEntity<?> entity, IdentifierProcessing identifierProcessing) {
+	SqlContext(RelationalPersistentEntity<?> entity) {
 
-		this.identifierProcessing = identifierProcessing;
 		this.entity = entity;
-		this.table = SQL.table(entity.getTableName().toSql(this.identifierProcessing));
+		this.table = Table.create(entity.getTableName());
 	}
 
 	Column getIdColumn() {
-		return table.column(entity.getIdColumn().toSql(identifierProcessing));
+		return table.column(entity.getIdColumn());
 	}
 
 	Column getVersionColumn() {
-		return table.column(entity.getRequiredVersionProperty().getColumnName().toSql(identifierProcessing));
+		return table.column(entity.getRequiredVersionProperty().getColumnName());
 	}
 
 	Table getTable() {
@@ -59,17 +55,15 @@ class SqlContext {
 	Table getTable(PersistentPropertyPathExtension path) {
 
 		SqlIdentifier tableAlias = path.getTableAlias();
-		Table table = SQL.table(path.getTableName().toSql(identifierProcessing));
-		return tableAlias == null ? table : table.as(tableAlias.toSql(identifierProcessing));
+		Table table = Table.create(path.getTableName());
+		return tableAlias == null ? table : table.as(tableAlias);
 	}
 
 	Column getColumn(PersistentPropertyPathExtension path) {
-		return getTable(path).column(path.getColumnName().toSql(identifierProcessing))
-				.as(path.getColumnAlias().toSql(identifierProcessing));
+		return getTable(path).column(path.getColumnName()).as(path.getColumnAlias());
 	}
 
 	Column getReverseColumn(PersistentPropertyPathExtension path) {
-		return getTable(path).column(path.getReverseColumnName().toSql(identifierProcessing))
-				.as(path.getReverseColumnNameAlias().toSql(identifierProcessing));
+		return getTable(path).column(path.getReverseColumnName()).as(path.getReverseColumnNameAlias());
 	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGeneratorSource.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGeneratorSource.java
@@ -28,6 +28,7 @@ import org.springframework.util.ConcurrentReferenceHashMap;
  * domain type, the same generator will get returned.
  *
  * @author Jens Schauder
+ * @author Mark Paluch
  */
 @RequiredArgsConstructor
 public class SqlGeneratorSource {
@@ -37,14 +38,15 @@ public class SqlGeneratorSource {
 	private final Dialect dialect;
 
 	/**
-	 * @return the {@link Dialect} used by the created {@link SqlGenerator} instances. Guaranteed to be not {@literal null}.
+	 * @return the {@link Dialect} used by the created {@link SqlGenerator} instances. Guaranteed to be not
+	 *         {@literal null}.
 	 */
 	public Dialect getDialect() {
 		return dialect;
 	}
 
-
 	SqlGenerator getSqlGenerator(Class<?> domainType) {
-		return CACHE.computeIfAbsent(domainType, t -> new SqlGenerator(context, context.getRequiredPersistentEntity(t), dialect.getIdentifierProcessing()));
+		return CACHE.computeIfAbsent(domainType,
+				t -> new SqlGenerator(context, context.getRequiredPersistentEntity(t), dialect));
 	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/JdbcMappingContext.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/JdbcMappingContext.java
@@ -85,7 +85,10 @@ public class JdbcMappingContext extends RelationalMappingContext {
 	@Override
 	protected RelationalPersistentProperty createPersistentProperty(Property property,
 			RelationalPersistentEntity<?> owner, SimpleTypeHolder simpleTypeHolder) {
-		return new BasicJdbcPersistentProperty(property, owner, simpleTypeHolder, this);
+		BasicJdbcPersistentProperty persistentProperty = new BasicJdbcPersistentProperty(property, owner, simpleTypeHolder,
+				this);
+		persistentProperty.setForceQuote(isForceQuote());
+		return persistentProperty;
 	}
 
 	@Override

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/IdentifierProcessingAdapter.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/IdentifierProcessingAdapter.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jdbc.core.convert;
+
+import org.springframework.data.relational.core.dialect.AbstractDialect;
+import org.springframework.data.relational.core.dialect.Dialect;
+import org.springframework.data.relational.core.dialect.HsqlDbDialect;
+import org.springframework.data.relational.core.dialect.LimitClause;
+import org.springframework.data.relational.core.sql.IdentifierProcessing;
+
+/**
+ * {@link Dialect} adapter that delegates to the given {@link IdentifierProcessing}.
+ *
+ * @author Mark Paluch
+ */
+public class IdentifierProcessingAdapter extends AbstractDialect implements Dialect {
+
+	private final IdentifierProcessing identifierProcessing;
+
+	public IdentifierProcessingAdapter(IdentifierProcessing identifierProcessing) {
+		this.identifierProcessing = identifierProcessing;
+	}
+
+	@Override
+	public LimitClause limit() {
+		return HsqlDbDialect.INSTANCE.limit();
+	}
+
+	@Override
+	public IdentifierProcessing getIdentifierProcessing() {
+		return identifierProcessing;
+	}
+}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorContextBasedNamingStrategyUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorContextBasedNamingStrategyUnitTests.java
@@ -24,6 +24,7 @@ import java.util.function.Consumer;
 
 import org.assertj.core.api.SoftAssertions;
 import org.junit.Test;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.jdbc.core.mapping.PersistentPropertyPathTestUtils;
@@ -32,9 +33,6 @@ import org.springframework.data.relational.core.mapping.NamingStrategy;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
-import org.springframework.data.relational.core.sql.IdentifierProcessing;
-import org.springframework.data.relational.core.sql.IdentifierProcessing.LetterCasing;
-import org.springframework.data.relational.core.sql.IdentifierProcessing.Quoting;
 
 /**
  * Unit tests to verify a contextual {@link NamingStrategy} implementation that customizes using a user-centric
@@ -218,8 +216,7 @@ public class SqlGeneratorContextBasedNamingStrategyUnitTests {
 		RelationalMappingContext context = new JdbcMappingContext(namingStrategy);
 		RelationalPersistentEntity<?> persistentEntity = context.getRequiredPersistentEntity(DummyEntity.class);
 
-		return new SqlGenerator(context, persistentEntity,
-				IdentifierProcessing.create(new Quoting(""), LetterCasing.AS_IS));
+		return new SqlGenerator(context, persistentEntity, UnquotedDialect.INSTANCE);
 	}
 
 	@SuppressWarnings("unused")

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorEmbeddedUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorEmbeddedUnitTests.java
@@ -22,6 +22,7 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.core.PropertyPathTestingUtils;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
@@ -32,9 +33,6 @@ import org.springframework.data.relational.core.mapping.PersistentPropertyPathEx
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.sql.Aliased;
-import org.springframework.data.relational.core.sql.IdentifierProcessing;
-import org.springframework.data.relational.core.sql.IdentifierProcessing.LetterCasing;
-import org.springframework.data.relational.core.sql.IdentifierProcessing.Quoting;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
 
 /**
@@ -55,8 +53,7 @@ public class SqlGeneratorEmbeddedUnitTests {
 
 	SqlGenerator createSqlGenerator(Class<?> type) {
 		RelationalPersistentEntity<?> persistentEntity = context.getRequiredPersistentEntity(type);
-		return new SqlGenerator(context, persistentEntity,
-				IdentifierProcessing.create(new Quoting(""), LetterCasing.AS_IS));
+		return new SqlGenerator(context, persistentEntity, UnquotedDialect.INSTANCE);
 	}
 
 	@Test // DATAJDBC-111

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorFixedNamingStrategyUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorFixedNamingStrategyUnitTests.java
@@ -24,11 +24,11 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.core.mapping.JdbcMappingContext;
 import org.springframework.data.jdbc.core.mapping.PersistentPropertyPathTestUtils;
 import org.springframework.data.mapping.PersistentPropertyPath;
+import org.springframework.data.relational.core.dialect.HsqlDbDialect;
 import org.springframework.data.relational.core.mapping.NamingStrategy;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
-import org.springframework.data.relational.core.sql.IdentifierProcessing;
 
 /**
  * Unit tests the {@link SqlGenerator} with a fixed {@link NamingStrategy} implementation containing a hard wired
@@ -196,7 +196,7 @@ public class SqlGeneratorFixedNamingStrategyUnitTests {
 
 		RelationalMappingContext context = new JdbcMappingContext(namingStrategy);
 		RelationalPersistentEntity<?> persistentEntity = context.getRequiredPersistentEntity(DummyEntity.class);
-		return new SqlGenerator(context, persistentEntity, IdentifierProcessing.ANSI);
+		return new SqlGenerator(context, persistentEntity, HsqlDbDialect.INSTANCE);
 	}
 
 	@SuppressWarnings("unused")

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
@@ -80,7 +80,7 @@ public class SqlGeneratorUnitTests {
 
 		RelationalPersistentEntity<?> persistentEntity = context.getRequiredPersistentEntity(type);
 
-		return new SqlGenerator(context, persistentEntity, identifierProcessing);
+		return new SqlGenerator(context, persistentEntity, new IdentifierProcessingAdapter(identifierProcessing));
 	}
 
 	@Test // DATAJDBC-112

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
@@ -41,11 +41,12 @@ import org.springframework.data.relational.core.mapping.RelationalMappingContext
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
 import org.springframework.data.relational.core.sql.Aliased;
-import org.springframework.data.relational.core.sql.Table;
-import org.springframework.data.relational.domain.Identifier;
 import org.springframework.data.relational.core.sql.IdentifierProcessing;
 import org.springframework.data.relational.core.sql.IdentifierProcessing.LetterCasing;
 import org.springframework.data.relational.core.sql.IdentifierProcessing.Quoting;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+import org.springframework.data.relational.core.sql.Table;
+import org.springframework.data.relational.domain.Identifier;
 
 /**
  * Unit tests for the {@link SqlGenerator}.
@@ -451,11 +452,11 @@ public class SqlGeneratorUnitTests {
 
 		SoftAssertions.assertSoftly(softly -> {
 
-			softly.assertThat(join.getJoinTable().getName()).isEqualTo("\"REFERENCED_ENTITY\"");
+			softly.assertThat(join.getJoinTable().getName()).isEqualTo(SqlIdentifier.quoted("REFERENCED_ENTITY"));
 			softly.assertThat(join.getJoinColumn().getTable()).isEqualTo(join.getJoinTable());
-			softly.assertThat(join.getJoinColumn().getName()).isEqualTo("\"DUMMY_ENTITY\"");
-			softly.assertThat(join.getParentId().getName()).isEqualTo("\"id1\"");
-			softly.assertThat(join.getParentId().getTable().getName()).isEqualTo("\"DUMMY_ENTITY\"");
+			softly.assertThat(join.getJoinColumn().getName()).isEqualTo(SqlIdentifier.quoted("DUMMY_ENTITY"));
+			softly.assertThat(join.getParentId().getName()).isEqualTo(SqlIdentifier.quoted("id1"));
+			softly.assertThat(join.getParentId().getTable().getName()).isEqualTo(SqlIdentifier.quoted("DUMMY_ENTITY"));
 		});
 	}
 
@@ -483,11 +484,12 @@ public class SqlGeneratorUnitTests {
 
 		SoftAssertions.assertSoftly(softly -> {
 
-			softly.assertThat(join.getJoinTable().getName()).isEqualTo("\"SECOND_LEVEL_REFERENCED_ENTITY\"");
+			softly.assertThat(join.getJoinTable().getName())
+					.isEqualTo(SqlIdentifier.quoted("SECOND_LEVEL_REFERENCED_ENTITY"));
 			softly.assertThat(join.getJoinColumn().getTable()).isEqualTo(join.getJoinTable());
-			softly.assertThat(join.getJoinColumn().getName()).isEqualTo("\"REFERENCED_ENTITY\"");
-			softly.assertThat(join.getParentId().getName()).isEqualTo("\"X_L1ID\"");
-			softly.assertThat(join.getParentId().getTable().getName()).isEqualTo("\"REFERENCED_ENTITY\"");
+			softly.assertThat(join.getJoinColumn().getName()).isEqualTo(SqlIdentifier.quoted("REFERENCED_ENTITY"));
+			softly.assertThat(join.getParentId().getName()).isEqualTo(SqlIdentifier.quoted("X_L1ID"));
+			softly.assertThat(join.getParentId().getTable().getName()).isEqualTo(SqlIdentifier.quoted("REFERENCED_ENTITY"));
 		});
 	}
 
@@ -499,13 +501,14 @@ public class SqlGeneratorUnitTests {
 
 		SoftAssertions.assertSoftly(softly -> {
 
-			softly.assertThat(joinTable.getName()).isEqualTo("\"NO_ID_CHILD\"");
+			softly.assertThat(joinTable.getName()).isEqualTo(SqlIdentifier.quoted("NO_ID_CHILD"));
 			softly.assertThat(joinTable).isInstanceOf(Aliased.class);
-			softly.assertThat(((Aliased) joinTable).getAlias()).isEqualTo("\"child\"");
+			softly.assertThat(((Aliased) joinTable).getAlias()).isEqualTo(SqlIdentifier.quoted("child"));
 			softly.assertThat(join.getJoinColumn().getTable()).isEqualTo(joinTable);
-			softly.assertThat(join.getJoinColumn().getName()).isEqualTo("\"PARENT_OF_NO_ID_CHILD\"");
-			softly.assertThat(join.getParentId().getName()).isEqualTo("\"X_ID\"");
-			softly.assertThat(join.getParentId().getTable().getName()).isEqualTo("\"PARENT_OF_NO_ID_CHILD\"");
+			softly.assertThat(join.getJoinColumn().getName()).isEqualTo(SqlIdentifier.quoted("PARENT_OF_NO_ID_CHILD"));
+			softly.assertThat(join.getParentId().getName()).isEqualTo(SqlIdentifier.quoted("X_ID"));
+			softly.assertThat(join.getParentId().getTable().getName())
+					.isEqualTo(SqlIdentifier.quoted("PARENT_OF_NO_ID_CHILD"));
 
 		});
 	}
@@ -520,7 +523,8 @@ public class SqlGeneratorUnitTests {
 
 		assertThat(generatedColumn("id", DummyEntity.class)) //
 				.extracting(c -> c.getName(), c -> c.getTable().getName(), c -> getAlias(c.getTable()), this::getAlias)
-				.containsExactly("\"id1\"", "\"DUMMY_ENTITY\"", null, "\"id1\"");
+				.containsExactly(SqlIdentifier.quoted("id1"), SqlIdentifier.quoted("DUMMY_ENTITY"), null,
+						SqlIdentifier.quoted("id1"));
 	}
 
 	@Test // DATAJDBC-340
@@ -528,7 +532,8 @@ public class SqlGeneratorUnitTests {
 
 		assertThat(generatedColumn("ref.l1id", DummyEntity.class)) //
 				.extracting(c -> c.getName(), c -> c.getTable().getName(), c -> getAlias(c.getTable()), this::getAlias) //
-				.containsExactly("\"X_L1ID\"", "\"REFERENCED_ENTITY\"", "\"ref\"", "\"REF_X_L1ID\"");
+				.containsExactly(SqlIdentifier.quoted("X_L1ID"), SqlIdentifier.quoted("REFERENCED_ENTITY"),
+						SqlIdentifier.quoted("ref"), SqlIdentifier.quoted("REF_X_L1ID"));
 	}
 
 	@Test // DATAJDBC-340
@@ -542,11 +547,11 @@ public class SqlGeneratorUnitTests {
 
 		assertThat(generatedColumn("child", ParentOfNoIdChild.class)) //
 				.extracting(c -> c.getName(), c -> c.getTable().getName(), c -> getAlias(c.getTable()), this::getAlias) //
-				.containsExactly("\"PARENT_OF_NO_ID_CHILD\"", "\"NO_ID_CHILD\"", "\"child\"",
-						"\"CHILD_PARENT_OF_NO_ID_CHILD\"");
+				.containsExactly(SqlIdentifier.quoted("PARENT_OF_NO_ID_CHILD"), SqlIdentifier.quoted("NO_ID_CHILD"),
+						SqlIdentifier.quoted("child"), SqlIdentifier.quoted("CHILD_PARENT_OF_NO_ID_CHILD"));
 	}
 
-	private String getAlias(Object maybeAliased) {
+	private SqlIdentifier getAlias(Object maybeAliased) {
 
 		if (maybeAliased instanceof Aliased) {
 			return ((Aliased) maybeAliased).getAlias();

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/UnquotedDialect.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/UnquotedDialect.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jdbc.core.convert;
+
+import org.springframework.data.relational.core.dialect.AbstractDialect;
+import org.springframework.data.relational.core.dialect.Dialect;
+import org.springframework.data.relational.core.dialect.HsqlDbDialect;
+import org.springframework.data.relational.core.dialect.LimitClause;
+import org.springframework.data.relational.core.sql.IdentifierProcessing;
+import org.springframework.data.relational.core.sql.IdentifierProcessing.LetterCasing;
+import org.springframework.data.relational.core.sql.IdentifierProcessing.Quoting;
+
+/**
+ * Simple {@link Dialect} that provides unquoted {@link IdentifierProcessing}.
+ *
+ * @author Mark Paluch
+ */
+public class UnquotedDialect extends AbstractDialect implements Dialect {
+
+	public static final UnquotedDialect INSTANCE = new UnquotedDialect();
+
+	private UnquotedDialect() {}
+
+	@Override
+	public LimitClause limit() {
+		return HsqlDbDialect.INSTANCE.limit();
+	}
+
+	@Override
+	public IdentifierProcessing getIdentifierProcessing() {
+		return IdentifierProcessing.create(new Quoting(""), LetterCasing.AS_IS);
+	}
+}

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>2.0.0.BUILD-SNAPSHOT</version>
+	<version>2.0.0.DATAJDBC-476-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.0.0.BUILD-SNAPSHOT</version>
+		<version>2.0.0.DATAJDBC-476-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/dialect/RenderContextFactory.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/dialect/RenderContextFactory.java
@@ -17,6 +17,7 @@ package org.springframework.data.relational.core.dialect;
 
 import lombok.RequiredArgsConstructor;
 
+import org.springframework.data.relational.core.sql.IdentifierProcessing;
 import org.springframework.data.relational.core.sql.render.NamingStrategies;
 import org.springframework.data.relational.core.sql.render.RenderContext;
 import org.springframework.data.relational.core.sql.render.RenderNamingStrategy;
@@ -68,7 +69,7 @@ public class RenderContextFactory {
 
 		SelectRenderContext select = dialect.getSelectContext();
 
-		return new DialectRenderContext(namingStrategy, select);
+		return new DialectRenderContext(namingStrategy, dialect.getIdentifierProcessing(), select);
 	}
 
 	/**
@@ -79,6 +80,8 @@ public class RenderContextFactory {
 
 		private final RenderNamingStrategy renderNamingStrategy;
 
+		private final IdentifierProcessing identifierProcessing;
+
 		private final SelectRenderContext selectRenderContext;
 
 		/*
@@ -88,6 +91,15 @@ public class RenderContextFactory {
 		@Override
 		public RenderNamingStrategy getNamingStrategy() {
 			return renderNamingStrategy;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.springframework.data.relational.core.sql.render.RenderContext#getIdentifierProcessing()
+		 */
+		@Override
+		public IdentifierProcessing getIdentifierProcessing() {
+			return identifierProcessing;
 		}
 
 		/*

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
@@ -130,11 +130,11 @@ public class BasicRelationalPersistentProperty extends AnnotationBasedPersistent
 		throw new UnsupportedOperationException();
 	}
 
-	boolean isForceQuote() {
+	public boolean isForceQuote() {
 		return forceQuote;
 	}
 
-	void setForceQuote(boolean forceQuote) {
+	public void setForceQuote(boolean forceQuote) {
 		this.forceQuote = forceQuote;
 	}
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/DerivedSqlIdentifier.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/DerivedSqlIdentifier.java
@@ -80,11 +80,14 @@ class DerivedSqlIdentifier implements SqlIdentifier {
 	@Override
 	public boolean equals(Object o) {
 
-		if (this == o)
+		if (this == o) {
 			return true;
+		}
+
 		if (o instanceof SqlIdentifier) {
 			return toString().equals(o.toString());
 		}
+
 		return false;
 	}
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/RelationalPersistentEntityImpl.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/RelationalPersistentEntityImpl.java
@@ -64,11 +64,11 @@ class RelationalPersistentEntityImpl<T> extends BasicPersistentEntity<T, Relatio
 		return new DerivedSqlIdentifier(name, isForceQuote());
 	}
 
-	boolean isForceQuote() {
+	public boolean isForceQuote() {
 		return forceQuote;
 	}
 
-	void setForceQuote(boolean forceQuote) {
+	public void setForceQuote(boolean forceQuote) {
 		this.forceQuote = forceQuote;
 	}
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/Aliased.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/Aliased.java
@@ -26,5 +26,5 @@ public interface Aliased {
 	/**
 	 * @return the alias name.
 	 */
-	String getAlias();
+	SqlIdentifier getAlias();
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/AliasedExpression.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/AliasedExpression.java
@@ -24,9 +24,17 @@ package org.springframework.data.relational.core.sql;
 class AliasedExpression extends AbstractSegment implements Aliased, Expression {
 
 	private final Expression expression;
-	private final String alias;
+	private final SqlIdentifier alias;
 
 	public AliasedExpression(Expression expression, String alias) {
+
+		super(expression);
+
+		this.expression = expression;
+		this.alias = SqlIdentifier.unquoted(alias);
+	}
+
+	public AliasedExpression(Expression expression, SqlIdentifier alias) {
 
 		super(expression);
 
@@ -39,7 +47,7 @@ class AliasedExpression extends AbstractSegment implements Aliased, Expression {
 	 * @see org.springframework.data.relational.core.sql.Aliased#getAlias()
 	 */
 	@Override
-	public String getAlias() {
+	public SqlIdentifier getAlias() {
 		return alias;
 	}
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/BindMarker.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/BindMarker.java
@@ -47,8 +47,8 @@ public class BindMarker extends AbstractSegment implements Expression {
 		 * @see org.springframework.data.relational.core.sql.Named#getName()
 		 */
 		@Override
-		public String getName() {
-			return name;
+		public SqlIdentifier getName() {
+			return SqlIdentifier.unquoted(name);
 		}
 
 		/*

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/DefaultSqlIdentifier.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/DefaultSqlIdentifier.java
@@ -76,13 +76,8 @@ class DefaultSqlIdentifier implements SqlIdentifier {
 	@Override
 	public boolean equals(Object o) {
 
-		if (this == o)
+		if (this == o) {
 			return true;
-
-		if (o instanceof DefaultSqlIdentifier) {
-			if (!quoted && !((DefaultSqlIdentifier) o).quoted) {
-				return toString().equalsIgnoreCase(o.toString());
-			}
 		}
 
 		if (o instanceof SqlIdentifier) {

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/DefaultSqlIdentifier.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/DefaultSqlIdentifier.java
@@ -78,9 +78,17 @@ class DefaultSqlIdentifier implements SqlIdentifier {
 
 		if (this == o)
 			return true;
+
+		if (o instanceof DefaultSqlIdentifier) {
+			if (!quoted && !((DefaultSqlIdentifier) o).quoted) {
+				return toString().equalsIgnoreCase(o.toString());
+			}
+		}
+
 		if (o instanceof SqlIdentifier) {
 			return toString().equals(o.toString());
 		}
+
 		return false;
 	}
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/Named.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/Named.java
@@ -26,5 +26,5 @@ public interface Named {
 	/**
 	 * @return the name of the underlying element.
 	 */
-	String getName();
+	SqlIdentifier getName();
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/SimpleFunction.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/SimpleFunction.java
@@ -65,6 +65,20 @@ public class SimpleFunction extends AbstractSegment implements Expression {
 
 		Assert.hasText(alias, "Alias must not be null or empty");
 
+		return new AliasedFunction(functionName, expressions, SqlIdentifier.unquoted(alias));
+	}
+
+	/**
+	 * Expose this function result under a column {@code alias}.
+	 *
+	 * @param alias column alias name, must not {@literal null}.
+	 * @return the aliased {@link SimpleFunction}.
+	 * @since 2.0
+	 */
+	public SimpleFunction as(SqlIdentifier alias) {
+
+		Assert.notNull(alias, "Alias must not be null");
+
 		return new AliasedFunction(functionName, expressions, alias);
 	}
 
@@ -97,9 +111,9 @@ public class SimpleFunction extends AbstractSegment implements Expression {
 	 */
 	static class AliasedFunction extends SimpleFunction implements Aliased {
 
-		private final String alias;
+		private final SqlIdentifier alias;
 
-		AliasedFunction(String functionName, List<Expression> expressions, String alias) {
+		AliasedFunction(String functionName, List<Expression> expressions, SqlIdentifier alias) {
 			super(functionName, expressions);
 			this.alias = alias;
 		}
@@ -109,7 +123,7 @@ public class SimpleFunction extends AbstractSegment implements Expression {
 		 * @see org.springframework.data.relational.core.sql.Aliased#getAlias()
 		 */
 		@Override
-		public String getAlias() {
+		public SqlIdentifier getAlias() {
 			return alias;
 		}
 	}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/SqlIdentifier.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/SqlIdentifier.java
@@ -70,6 +70,17 @@ public interface SqlIdentifier {
 	String getReference(IdentifierProcessing processing);
 
 	/**
+	 * Return the reference name without any further transformation. The reference name is used for programmatic access to
+	 * the object identified by this {@link SqlIdentifier}.
+	 *
+	 * @return
+	 * @see IdentifierProcessing#NONE
+	 */
+	default String getReference() {
+		return getReference(IdentifierProcessing.NONE);
+	}
+
+	/**
 	 * Return the identifier for SQL usage after applying {@link IdentifierProcessing} rules. The identifier name is used
 	 * to construct SQL statements.
 	 *

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/Table.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/Table.java
@@ -33,9 +33,14 @@ import org.springframework.util.Assert;
  */
 public class Table extends AbstractSegment {
 
-	private final String name;
+	private final SqlIdentifier name;
 
 	Table(String name) {
+		super();
+		this.name = SqlIdentifier.unquoted(name);
+	}
+
+	Table(SqlIdentifier name) {
 		super();
 		this.name = name;
 	}
@@ -48,7 +53,21 @@ public class Table extends AbstractSegment {
 	 */
 	public static Table create(String name) {
 
-		Assert.hasText(name, "Name must not be null or empty!");
+		Assert.hasText(name, "Name must not be null or empty");
+
+		return new Table(name);
+	}
+
+	/**
+	 * Creates a new {@link Table} given {@code name}.
+	 *
+	 * @param name must not be {@literal null} or empty.
+	 * @return the new {@link Table}.
+	 * @since 2.0
+	 */
+	public static Table create(SqlIdentifier name) {
+
+		Assert.notNull(name, "Name must not be null");
 
 		return new Table(name);
 	}
@@ -78,6 +97,20 @@ public class Table extends AbstractSegment {
 
 		Assert.hasText(alias, "Alias must not be null or empty!");
 
+		return new AliasedTable(name, SqlIdentifier.unquoted(alias));
+	}
+
+	/**
+	 * Creates a new {@link Table} aliased to {@code alias}.
+	 *
+	 * @param alias must not be {@literal null} or empty.
+	 * @return the new {@link Table} using the {@code alias}.
+	 * @since 2.0
+	 */
+	public Table as(SqlIdentifier alias) {
+
+		Assert.notNull(alias, "Alias must not be null");
+
 		return new AliasedTable(name, alias);
 	}
 
@@ -98,6 +131,23 @@ public class Table extends AbstractSegment {
 	}
 
 	/**
+	 * Creates a new {@link Column} associated with this {@link Table}.
+	 * <p/>
+	 * Note: This {@link Table} does not track column creation and there is no possibility to enumerate all
+	 * {@link Column}s that were created for this table.
+	 *
+	 * @param name column name, must not be {@literal null} or empty.
+	 * @return a new {@link Column} associated with this {@link Table}.
+	 * @since 2.0
+	 */
+	public Column column(SqlIdentifier name) {
+
+		Assert.notNull(name, "Name must not be null");
+
+		return new Column(name, this);
+	}
+
+	/**
 	 * Creates a {@link List} of {@link Column}s associated with this {@link Table}.
 	 * <p/>
 	 * Note: This {@link Table} does not track column creation and there is no possibility to enumerate all
@@ -111,6 +161,28 @@ public class Table extends AbstractSegment {
 		Assert.notNull(names, "Names must not be null");
 
 		return columns(Arrays.asList(names));
+	}
+
+	/**
+	 * Creates a {@link List} of {@link Column}s associated with this {@link Table}.
+	 * <p/>
+	 * Note: This {@link Table} does not track column creation and there is no possibility to enumerate all
+	 * {@link Column}s that were created for this table.
+	 *
+	 * @param names column names, must not be {@literal null} or empty.
+	 * @return a new {@link List} of {@link Column}s associated with this {@link Table}.
+	 * @since 2.0
+	 */
+	public List<Column> columns(SqlIdentifier... names) {
+
+		Assert.notNull(names, "Names must not be null");
+
+		List<Column> columns = new ArrayList<>();
+		for (SqlIdentifier name : names) {
+			columns.add(column(name));
+		}
+
+		return columns;
 	}
 
 	/**
@@ -153,7 +225,7 @@ public class Table extends AbstractSegment {
 	 * (non-Javadoc)
 	 * @see org.springframework.data.relational.core.sql.Named#getName()
 	 */
-	public String getName() {
+	public SqlIdentifier getName() {
 		return name;
 	}
 
@@ -161,7 +233,7 @@ public class Table extends AbstractSegment {
 	 * @return the table name as it is used in references. This can be the actual {@link #getName() name} or an
 	 *         {@link Aliased#getAlias() alias}.
 	 */
-	public String getReferenceName() {
+	public SqlIdentifier getReferenceName() {
 		return name;
 	}
 
@@ -171,7 +243,7 @@ public class Table extends AbstractSegment {
 	 */
 	@Override
 	public String toString() {
-		return name;
+		return name.toString();
 	}
 
 	/**
@@ -179,12 +251,20 @@ public class Table extends AbstractSegment {
 	 */
 	static class AliasedTable extends Table implements Aliased {
 
-		private final String alias;
+		private final SqlIdentifier alias;
 
 		AliasedTable(String name, String alias) {
 			super(name);
 
-			Assert.hasText(alias, "Alias must not be null or empty!");
+			Assert.hasText(alias, "Alias must not be null or empty");
+
+			this.alias = SqlIdentifier.unquoted(alias);
+		}
+
+		AliasedTable(SqlIdentifier name, SqlIdentifier alias) {
+			super(name);
+
+			Assert.notNull(alias, "Alias must not be null");
 
 			this.alias = alias;
 		}
@@ -194,7 +274,7 @@ public class Table extends AbstractSegment {
 		 * @see org.springframework.data.relational.core.sql.Aliased#getAlias()
 		 */
 		@Override
-		public String getAlias() {
+		public SqlIdentifier getAlias() {
 			return alias;
 		}
 
@@ -203,7 +283,7 @@ public class Table extends AbstractSegment {
 		 * @see org.springframework.data.relational.core.sql.Table#getReferenceName()
 		 */
 		@Override
-		public String getReferenceName() {
+		public SqlIdentifier getReferenceName() {
 			return getAlias();
 		}
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/ExpressionVisitor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/ExpressionVisitor.java
@@ -61,14 +61,13 @@ class ExpressionVisitor extends TypedSubtreeVisitor<Expression> implements PartR
 
 		if (segment instanceof Column) {
 
-			RenderNamingStrategy namingStrategy = context.getNamingStrategy();
 			Column column = (Column) segment;
 
-			value = namingStrategy.getReferenceName(column.getTable()) + "." + namingStrategy.getReferenceName(column);
+			value = NameRenderer.fullyQualifiedReference(context, column);
 		} else if (segment instanceof BindMarker) {
 
 			if (segment instanceof Named) {
-				value = ((Named) segment).getName();
+				value = NameRenderer.render(context, (Named) segment);
 			} else {
 				value = segment.toString();
 			}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/FromTableVisitor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/FromTableVisitor.java
@@ -47,9 +47,9 @@ class FromTableVisitor extends TypedSubtreeVisitor<Table> {
 
 		StringBuilder builder = new StringBuilder();
 
-		builder.append(context.getNamingStrategy().getName(segment));
+		builder.append(NameRenderer.render(context, segment));
 		if (segment instanceof Aliased) {
-			builder.append(" ").append(((Aliased) segment).getAlias());
+			builder.append(" ").append(NameRenderer.render(context, (Aliased) segment));
 		}
 
 		parent.onRendered(builder);

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/JoinVisitor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/JoinVisitor.java
@@ -61,9 +61,9 @@ class JoinVisitor extends TypedSubtreeVisitor<Join> {
 	Delegation enterNested(Visitable segment) {
 
 		if (segment instanceof Table && !inCondition) {
-			joinClause.append(context.getNamingStrategy().getName(((Table) segment)));
+			joinClause.append(NameRenderer.render(context, (Table) segment));
 			if (segment instanceof Aliased) {
-				joinClause.append(" AS ").append(((Aliased) segment).getAlias());
+				joinClause.append(" AS ").append(NameRenderer.render(context, (Aliased) segment));
 			}
 		} else if (segment instanceof Condition) {
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/NameRenderer.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/NameRenderer.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.relational.core.sql.render;
+
+import org.springframework.data.relational.core.sql.Aliased;
+import org.springframework.data.relational.core.sql.Column;
+import org.springframework.data.relational.core.sql.IdentifierProcessing;
+import org.springframework.data.relational.core.sql.Named;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
+import org.springframework.data.relational.core.sql.Table;
+
+/**
+ * Utility to render {@link Column} and {@link Table} names using {@link SqlIdentifier} and {@link RenderContext} to
+ * SQL.
+ *
+ * @author Mark Paluch
+ */
+class NameRenderer {
+
+	/**
+	 * Render the {@link Table#getName() table name } with considering the {@link RenderNamingStrategy#getName(Table)
+	 * naming strategy}.
+	 *
+	 * @param context
+	 * @param table
+	 * @return
+	 */
+	static CharSequence render(RenderContext context, Table table) {
+		return render(context, context.getNamingStrategy().getName(table));
+	}
+
+	/**
+	 * Render the {@link Column#getName() column name} with considering the {@link RenderNamingStrategy#getName(Column)
+	 * naming strategy}.
+	 *
+	 * @param context
+	 * @param table
+	 * @return
+	 */
+	static CharSequence render(RenderContext context, Column column) {
+		return render(context, context.getNamingStrategy().getName(column));
+	}
+
+	/**
+	 * Render the {@link Named#getName() name}.
+	 *
+	 * @param context
+	 * @param table
+	 * @return
+	 */
+	static CharSequence render(RenderContext context, Named named) {
+		return render(context, named.getName());
+	}
+
+	/**
+	 * Render the {@link Aliased#getAlias() alias}.
+	 *
+	 * @param context
+	 * @param table
+	 * @return
+	 */
+	static CharSequence render(RenderContext context, Aliased aliased) {
+		return render(context, aliased.getAlias());
+	}
+
+	/**
+	 * Render the {@link Table#getReferenceName()} table reference name} with considering the
+	 * {@link RenderNamingStrategy#getReferenceName(Table) naming strategy}.
+	 *
+	 * @param context
+	 * @param table
+	 * @return
+	 */
+	static CharSequence reference(RenderContext context, Table table) {
+		return render(context, context.getNamingStrategy().getReferenceName(table));
+	}
+
+	/**
+	 * Render the {@link Column#getReferenceName()} column reference name} with considering the
+	 * {@link RenderNamingStrategy#getReferenceName(Column) naming strategy}.
+	 *
+	 * @param context
+	 * @param table
+	 * @return
+	 */
+	static CharSequence reference(RenderContext context, Column column) {
+		return render(context, context.getNamingStrategy().getReferenceName(column));
+	}
+
+	/**
+	 * Render the fully-qualified table and column name with considering the naming strategies of each component.
+	 *
+	 * @param context
+	 * @param column
+	 * @return
+	 * @see RenderNamingStrategy#getReferenceName
+	 */
+	static CharSequence fullyQualifiedReference(RenderContext context, Column column) {
+
+		RenderNamingStrategy namingStrategy = context.getNamingStrategy();
+
+		return render(context, SqlIdentifier.from(namingStrategy.getReferenceName(column.getTable()),
+				namingStrategy.getReferenceName(column)));
+	}
+
+	/**
+	 * Render the {@link SqlIdentifier#toSql(IdentifierProcessing) identifier to SQL} considering
+	 * {@link IdentifierProcessing}.
+	 *
+	 * @param context
+	 * @param identifier
+	 * @return
+	 */
+	static CharSequence render(RenderContext context, SqlIdentifier identifier) {
+		return identifier.toSql(context.getIdentifierProcessing());
+	}
+
+	private NameRenderer() {}
+}

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/NamingStrategies.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/NamingStrategies.java
@@ -21,6 +21,7 @@ import java.util.Locale;
 import java.util.function.Function;
 
 import org.springframework.data.relational.core.sql.Column;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
 import org.springframework.data.relational.core.sql.Table;
 import org.springframework.util.Assert;
 
@@ -121,23 +122,23 @@ public abstract class NamingStrategies {
 		private final Function<String, String> mappingFunction;
 
 		@Override
-		public String getName(Column column) {
-			return mappingFunction.apply(delegate.getName(column));
+		public SqlIdentifier getName(Column column) {
+			return delegate.getName(column).transform(mappingFunction::apply);
 		}
 
 		@Override
-		public String getReferenceName(Column column) {
-			return mappingFunction.apply(delegate.getReferenceName(column));
+		public SqlIdentifier getReferenceName(Column column) {
+			return delegate.getReferenceName(column).transform(mappingFunction::apply);
 		}
 
 		@Override
-		public String getName(Table table) {
-			return mappingFunction.apply(delegate.getName(table));
+		public SqlIdentifier getName(Table table) {
+			return delegate.getName(table).transform(mappingFunction::apply);
 		}
 
 		@Override
-		public String getReferenceName(Table table) {
-			return mappingFunction.apply(delegate.getReferenceName(table));
+		public SqlIdentifier getReferenceName(Table table) {
+			return delegate.getReferenceName(table).transform(mappingFunction::apply);
 		}
 	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/OrderByClauseVisitor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/OrderByClauseVisitor.java
@@ -77,7 +77,7 @@ class OrderByClauseVisitor extends TypedSubtreeVisitor<OrderByField> implements 
 	Delegation leaveNested(Visitable segment) {
 
 		if (segment instanceof Column) {
-			builder.append(context.getNamingStrategy().getReferenceName(((Column) segment)));
+			builder.append(NameRenderer.reference(context, (Column) segment));
 		}
 
 		return super.leaveNested(segment);

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/RenderContext.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/RenderContext.java
@@ -15,6 +15,8 @@
  */
 package org.springframework.data.relational.core.sql.render;
 
+import org.springframework.data.relational.core.sql.IdentifierProcessing;
+
 /**
  * Render context providing {@link RenderNamingStrategy} and other resources that are required during rendering.
  *
@@ -29,6 +31,14 @@ public interface RenderContext {
 	 * @return the {@link RenderNamingStrategy}.
 	 */
 	RenderNamingStrategy getNamingStrategy();
+
+	/**
+	 * Returns the configured {@link IdentifierProcessing}.
+	 *
+	 * @return the {@link IdentifierProcessing}.
+	 * @since 2.0
+	 */
+	IdentifierProcessing getIdentifierProcessing();
 
 	/**
 	 * @return the {@link SelectRenderContext}.

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/RenderNamingStrategy.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/RenderNamingStrategy.java
@@ -18,6 +18,7 @@ package org.springframework.data.relational.core.sql.render;
 import java.util.function.Function;
 
 import org.springframework.data.relational.core.sql.Column;
+import org.springframework.data.relational.core.sql.SqlIdentifier;
 import org.springframework.data.relational.core.sql.Table;
 import org.springframework.data.relational.core.sql.render.NamingStrategies.DelegatingRenderNamingStrategy;
 import org.springframework.util.Assert;
@@ -38,7 +39,7 @@ public interface RenderNamingStrategy {
 	 * @return the {@link Column#getName() column name}.
 	 * @see Column#getName()
 	 */
-	default String getName(Column column) {
+	default SqlIdentifier getName(Column column) {
 		return column.getName();
 	}
 
@@ -49,7 +50,7 @@ public interface RenderNamingStrategy {
 	 * @return the {@link Column#getName() column reference name}.
 	 * @see Column#getReferenceName() ()
 	 */
-	default String getReferenceName(Column column) {
+	default SqlIdentifier getReferenceName(Column column) {
 		return column.getReferenceName();
 	}
 
@@ -60,7 +61,7 @@ public interface RenderNamingStrategy {
 	 * @return the {@link Table#getName() table name}.
 	 * @see Table#getName()
 	 */
-	default String getName(Table table) {
+	default SqlIdentifier getName(Table table) {
 		return table.getName();
 	}
 
@@ -71,7 +72,7 @@ public interface RenderNamingStrategy {
 	 * @return the {@link Table#getReferenceName() table name}.
 	 * @see Table#getReferenceName()
 	 */
-	default String getReferenceName(Table table) {
+	default SqlIdentifier getReferenceName(Table table) {
 		return table.getReferenceName();
 	}
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/SelectListVisitor.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/SelectListVisitor.java
@@ -40,7 +40,6 @@ class SelectListVisitor extends TypedSubtreeVisitor<SelectList> implements PartR
 	private boolean insideFunction = false; // this is hackery and should be fix with a proper visitor for
 	// subelements.
 
-
 	SelectListVisitor(RenderContext context, RenderTarget target) {
 		this.context = context;
 		this.target = target;
@@ -84,14 +83,14 @@ class SelectListVisitor extends TypedSubtreeVisitor<SelectList> implements PartR
 	Delegation leaveNested(Visitable segment) {
 
 		if (segment instanceof Table) {
-			builder.append(context.getNamingStrategy().getReferenceName((Table) segment)).append('.');
+			builder.append(NameRenderer.reference(context, (Table) segment)).append('.');
 		}
 
 		if (segment instanceof SimpleFunction) {
 
 			builder.append(")");
 			if (segment instanceof Aliased) {
-				builder.append(" AS ").append(((Aliased) segment).getAlias());
+				builder.append(" AS ").append(NameRenderer.render(context, (Aliased) segment));
 			}
 
 			insideFunction = false;
@@ -101,9 +100,9 @@ class SelectListVisitor extends TypedSubtreeVisitor<SelectList> implements PartR
 			requiresComma = true;
 		} else if (segment instanceof Column) {
 
-			builder.append(context.getNamingStrategy().getName((Column) segment));
+			builder.append(NameRenderer.render(context, (Column) segment));
 			if (segment instanceof Aliased && !insideFunction) {
-				builder.append(" AS ").append(((Aliased) segment).getAlias());
+				builder.append(" AS ").append(NameRenderer.render(context, (Aliased) segment));
 			}
 			requiresComma = true;
 		} else if (segment instanceof AsteriskFromTable) {

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/SimpleRenderContext.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/render/SimpleRenderContext.java
@@ -17,6 +17,8 @@ package org.springframework.data.relational.core.sql.render;
 
 import lombok.Value;
 
+import org.springframework.data.relational.core.sql.IdentifierProcessing;
+
 /**
  * Default {@link RenderContext} implementation.
  *
@@ -27,6 +29,11 @@ import lombok.Value;
 class SimpleRenderContext implements RenderContext {
 
 	private final RenderNamingStrategy namingStrategy;
+
+	@Override
+	public IdentifierProcessing getIdentifierProcessing() {
+		return IdentifierProcessing.NONE;
+	}
 
 	@Override
 	public SelectRenderContext getSelect() {

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/SelectBuilderUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/SelectBuilderUnitTests.java
@@ -73,7 +73,7 @@ public class SelectBuilderUnitTests {
 		Column foo = table.column("foo");
 
 		Comparison condition = foo.isEqualTo(SQL.literalOf("bar"));
-		Select select = builder.select(foo).from(table.getName()).where(condition).build();
+		Select select = builder.select(foo).from(table).where(condition).build();
 
 		CapturingVisitor visitor = new CapturingVisitor();
 		select.visit(visitor);


### PR DESCRIPTION
We now use `SqlIdentifier` to encapsulate names and aliases of tables, columns and functions.

This change also introduces proper delegation to ConditionVisitor to render a `JOIN` condition. Previously, we used `toString()` of `Condition` segments which rendered an approximation of the condition. `ConditionVisitor` applies `RenderContext` settings that consider identifier quoting and normalization strategies.

---

Related ticket: [DATAJDBC-479](https://jira.spring.io/browse/DATAJDBC-479).