### PR TITLE
Public to Dialect Bean registration method of AbstractJdbcConfiguration

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/AbstractJdbcConfiguration.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/AbstractJdbcConfiguration.java
@@ -48,6 +48,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
  * @author Mark Paluch
  * @author Michael Simons
  * @author Christoph Strobl
+ * @author Myeonghyeon Lee
  * @since 1.1
  */
 @Configuration(proxyBeanMethods = false)
@@ -133,7 +134,7 @@ public class AbstractJdbcConfiguration {
 	}
 
 	@Bean
-	Dialect dialect() {
+	public Dialect dialect() {
 		return HsqlDbDialect.INSTANCE;
 	}
 }


### PR DESCRIPTION
The dialect method of the deprecated JdbcConfiguration is public.
https://github.com/spring-projects/spring-data-jdbc/blob/f1d2d78dc86aa60f3997d108d99e76370fc06f47/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/JdbcConfiguration.java#L136

However, the dialect method of AbstractJdbcConfiguration is package-public and cannot be override.

I want to change the accessor to public to override the Dialect.
