### PR TITLE
Improved documentation for MappedCollection annotation

### DIFF
--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/MappedCollection.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/MappedCollection.java
@@ -22,9 +22,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
- * The annotation to configure the mapping for a {@link List} or {@link Map} property in the database.
+ * The annotation to configure the mapping for a {@link List}, {@link Set} or {@link Map} property in the database.
  *
  * @since 1.1
  * @author Bastian Wilhelm

--- a/src/main/asciidoc/jdbc.adoc
+++ b/src/main/asciidoc/jdbc.adoc
@@ -271,10 +271,9 @@ public class MyEntity {
 ----
 ====
 
-The {javadoc-base}org/springframework/data/relational/core/mapping/MappedCollection.html[`@MappedCollection`] annotation can be used on a reference type (one-to-one relationship) or on Sets, Lists, and Maps (one-to-many relationship)
-On all these types the `value` element of the annotation is used to provide a custom name for the foreign key column referencing the id column in the other table.
-In the following example the corresponding table for the `MySubEntity` class has a name column, and the id column of the `MyEntity` id for relationship reasons.
-The name of this `MySubEntity` class's id column can also be customized with the `idColumn` element of the {javadoc-base}org/springframework/data/relational/core/mapping/MappedCollection.html[`@MappedCollection`] annotation:
+The {javadoc-base}org/springframework/data/relational/core/mapping/MappedCollection.html[`@MappedCollection`] annotation can be used on Sets, Lists, and Maps.
+`idColumn` element of the annotation provides a custom name for the foreign key column referencing the id column in the other table.
+In the following example the corresponding table for the `MySubEntity` class has a `NAME` column, and the `CUSTOM_MY_ENTITY_ID_COLUMN_NAME` column of the `MyEntity` id for relationship reasons:
 
 ====
 [source, java]
@@ -283,8 +282,8 @@ public class MyEntity {
     @Id
     Integer id;
 
-    @MappedCollection(idColumn = "CUSTOM_COLUMN_NAME")
-    Set<MySubEntity> name;
+    @MappedCollection(idColumn = "CUSTOM_MY_ENTITY_ID_COLUMN_NAME")
+    Set<MySubEntity> subEntities;
 }
 
 public class MySubEntity {


### PR DESCRIPTION
Current documentation for `MappedCollection` has some issues:
* Refers to `value` attribute that does not exist any more for this annotation.
* Suggests its usage for one-to-one relations while it can only be used on a collection.
* Suggests annotating a referenced type while the annotation is not applicable for the class.

This PR suggests documentation improvements to address these issues.