### PR TITLE
[DATAJDBC-530] The sorting property set as the property name.

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
@@ -52,6 +52,7 @@ import org.springframework.util.Assert;
  * @author Tom Hombergs
  * @author Tyler Van Gorder
  * @author Milan Milanov
+ * @author Myeonghyeon Lee
  */
 class SqlGenerator {
 
@@ -659,7 +660,13 @@ class SqlGenerator {
 
 	private List<OrderByField> extractOrderByFields(Sort sort) {
 		return sort.stream()
-				.map(order -> OrderByField.from(Column.create(order.getProperty(), this.getTable()), order.getDirection()))
+				.map(order -> {
+					Column column = Column.create(
+						this.entity.getRequiredPersistentProperty(order.getProperty()).getColumnName(),
+						this.getTable()
+					);
+					return OrderByField.from(column, order.getDirection());
+				})
 				.collect(Collectors.toList());
 	}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlGeneratorUnitTests.java
@@ -59,6 +59,7 @@ import org.springframework.data.relational.core.sql.Table;
  * @author Mark Paluch
  * @author Tom Hombergs
  * @author Milan Milanov
+ * @author Myeonghyeon Lee
  */
 public class SqlGeneratorUnitTests {
 
@@ -177,7 +178,7 @@ public class SqlGeneratorUnitTests {
 	@Test // DATAJDBC-101
 	public void findAllSortedBySingleField() {
 
-		String sql = sqlGenerator.getFindAll(Sort.by("x_name"));
+		String sql = sqlGenerator.getFindAll(Sort.by("name"));
 
 		assertThat(sql).contains("SELECT", //
 				"dummy_entity.id1 AS id1", //
@@ -197,7 +198,7 @@ public class SqlGeneratorUnitTests {
 	public void findAllSortedByMultipleFields() {
 
 		String sql = sqlGenerator.getFindAll(
-				Sort.by(new Sort.Order(Sort.Direction.DESC, "x_name"), new Sort.Order(Sort.Direction.ASC, "x_other")));
+				Sort.by(new Sort.Order(Sort.Direction.DESC, "name"), new Sort.Order(Sort.Direction.ASC, "other")));
 
 		assertThat(sql).contains("SELECT", //
 				"dummy_entity.id1 AS id1", //
@@ -245,7 +246,7 @@ public class SqlGeneratorUnitTests {
 	@Test // DATAJDBC-101
 	public void findAllPagedAndSorted() {
 
-		String sql = sqlGenerator.getFindAll(PageRequest.of(3, 10, Sort.by("x_name")));
+		String sql = sqlGenerator.getFindAll(PageRequest.of(3, 10, Sort.by("name")));
 
 		assertThat(sql).contains("SELECT", //
 				"dummy_entity.id1 AS id1", //


### PR DESCRIPTION
resovle: [DATAJDBC-530](https://jira.spring.io/browse/DATAJDBC-530) 

sort property set as entity property name instead of column name
https://github.com/spring-projects/spring-data-jdbc/pull/210/files#diff-e13aa431d1a566b80b029d2e360c3cedR181
