### PR TITLE
DATAJDBC-569 - Use JdbcUtils to obtain values from a ResultSet.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.0-DATAJDBC-569-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.0-DATAJDBC-569-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.0-DATAJDBC-569-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.0-DATAJDBC-569-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/ResultSetAccessor.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/ResultSetAccessor.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.mapping.MappingException;
+import org.springframework.jdbc.support.JdbcUtils;
 import org.springframework.lang.Nullable;
 import org.springframework.util.LinkedCaseInsensitiveMap;
 
@@ -89,7 +90,7 @@ class ResultSetAccessor {
 		try {
 
 			int index = findColumnIndex(columnName);
-			return index > 0 ? resultSet.getObject(index) : null;
+			return index > 0 ? JdbcUtils.getResultSetValue(resultSet, index) : null;
 		} catch (SQLException o_O) {
 			throw new MappingException(String.format("Could not read value %s from result set!", columnName), o_O);
 		}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryIntegrationTests.java
@@ -259,7 +259,6 @@ public class JdbcRepositoryIntegrationTests {
 	}
 
 	@Test // DATAJDBC-464, DATAJDBC-318
-	@EnabledOnFeature(SUPPORTS_DATE_DATATYPES)
 	public void executeQueryWithParameterRequiringConversion() {
 
 		Instant now = Instant.now();

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/TestDatabaseFeatures.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/TestDatabaseFeatures.java
@@ -43,25 +43,10 @@ public class TestDatabaseFeatures {
 	}
 
 	/**
-	 * Oracle returns an oracle.sql.TIMESTAMP which currently cannot be converted to an Instant. See DATAJDBC-569 for
-	 * reference.
-	 */
-	private void supportsDateDataTypes() {
-		assumeThat(database).isNotEqualTo(Database.Oracle);
-	}
-
-	/**
 	 * Not all databases support really huge numbers as represented by {@link java.math.BigDecimal} and similar.
 	 */
 	private void supportsHugeNumbers() {
 		assumeThat(database).isNotIn(Database.Oracle, Database.SqlServer);
-	}
-
-	/**
-	 * Oracle does not allow to specify an alias for a joined table with {@code AS}. See DATAJDBC-570 for reference.
-	 */
-	private void supportsAsForJoinAlias() {
-		assumeThat(database).isNotEqualTo(Database.Oracle);
 	}
 
 	/**
@@ -119,7 +104,6 @@ public class TestDatabaseFeatures {
 
 	public enum Feature {
 
-		SUPPORTS_DATE_DATATYPES(TestDatabaseFeatures::supportsDateDataTypes), //
 		SUPPORTS_MULTIDIMENSIONAL_ARRAYS(TestDatabaseFeatures::supportsMultiDimensionalArrays), //
 		SUPPORTS_QUOTED_IDS(TestDatabaseFeatures::supportsQuotedIds), //
 		SUPPORTS_HUGE_NUMBERS(TestDatabaseFeatures::supportsHugeNumbers), //

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.0-DATAJDBC-569-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.0-DATAJDBC-569-SNAPSHOT</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
Fixes the failure to properly handle Oracle Resultsets with date data types.

DATAJDBC-569.