### PR TITLE
DATAJDBC-573 - fixes the wait strategy for Oracle data sources.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.0-DATAJDBC-573-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.0-DATAJDBC-573-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.0-DATAJDBC-573-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.0-DATAJDBC-573-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/Db2DataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/Db2DataSourceConfiguration.java
@@ -32,6 +32,8 @@ import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
 
 import org.testcontainers.containers.Db2Container;
 
+import static org.awaitility.pollinterval.FibonacciPollInterval.*;
+
 /**
  * {@link DataSource} setup for DB2.
  *
@@ -65,18 +67,6 @@ class Db2DataSourceConfiguration extends DataSourceConfiguration {
 
 		DriverManagerDataSource dataSource = new DriverManagerDataSource(DB_2_CONTAINER.getJdbcUrl(),
 				DB_2_CONTAINER.getUsername(), DB_2_CONTAINER.getPassword());
-
-		// DB2 container says its ready but it's like with a cat that denies service and still wants food although it had
-		// its food. Therefore, we make sure that we can properly establish a connection instead of trusting the cat
-		// ...err... DB2.
-		Awaitility.await().ignoreException(SQLException.class).until(() -> {
-
-			try (Connection connection = dataSource.getConnection()) {
-				return true;
-			}
-		});
-
-		LOG.info("DB2 connectivity verified");
 
 		return dataSource;
 	}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/OracleDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/OracleDataSourceConfiguration.java
@@ -15,23 +15,14 @@
  */
 package org.springframework.data.jdbc.testing;
 
-import static org.awaitility.pollinterval.FibonacciPollInterval.*;
-
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.util.concurrent.TimeUnit;
-
 import javax.sql.DataSource;
 
-import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 import org.springframework.jdbc.datasource.init.ResourceDatabasePopulator;
-
 import org.testcontainers.containers.OracleContainer;
 
 /**
@@ -61,8 +52,10 @@ public class OracleDataSourceConfiguration extends DataSourceConfiguration {
 
 		if (ORACLE_CONTAINER == null) {
 
+			LOG.info("Oracle starting...");
 			OracleContainer container = new OracleContainer("springci/spring-data-oracle-xe-prebuild:18.4.0").withReuse(true);
 			container.start();
+			LOG.info("Oracle started");
 
 			ORACLE_CONTAINER = container;
 		}
@@ -71,17 +64,6 @@ public class OracleDataSourceConfiguration extends DataSourceConfiguration {
 
 		DataSource dataSource = new DriverManagerDataSource(jdbcUrl, ORACLE_CONTAINER.getUsername(),
 				ORACLE_CONTAINER.getPassword());
-
-		// Oracle container says its ready but it's like with a cat that denies service and still wants food although it had
-		// its food. Therefore, we make sure that we can properly establish a connection instead of trusting the cat
-		// ...err... Oracle.
-		Awaitility.await().atMost(5L, TimeUnit.MINUTES).pollInterval(fibonacci(TimeUnit.SECONDS))
-				.ignoreException(SQLException.class).until(() -> {
-
-					try (Connection connection = dataSource.getConnection()) {
-						return true;
-					}
-				});
 
 		return dataSource;
 	}

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.0-DATAJDBC-573-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.0-DATAJDBC-573-SNAPSHOT</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
Oracle integration tests where failing when the docker container was freshly started,
as it happens every time on CI.

The reason was mainly a misuse of `Awaitility.ignoreException(Class)` which only ignores exception of exactly the class provided, not of subtypes.

Apart from fixing this for Oracle the complete logic for verifying the connection was moved to DataSourceConfiguration so other database use it as well in a consistent manner.

DATAJDBC-573.