### PR TITLE
DATAJDBC-576 - Control test execution with missing licence via profile.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -148,6 +148,36 @@ If you want to build with the regular `mvn` command, you will need https://maven
 
 _Also see link:CONTRIBUTING.adoc[CONTRIBUTING.adoc] if you wish to submit pull requests, and in particular please sign the https://cla.pivotal.io/sign/spring[Contributor’s Agreement] before your first non-trivial change._
 
+=== Running Integration Tests
+
+[source,bash]
+----
+ $ ./mvnw clean install
+----
+
+Runs integration test against a single in memory database.
+
+To run integration tests against all supported databases specify the Maven Profile `all-dbs`.
+
+```
+./mvnw clean install -Pall-dbs
+```
+
+This requires an appropriate `container-license-acceptance.txt` to be on the classpath, signaling that you accept the licence of the databases used.
+
+If you don't want to accept these licences you may add the Maven Profile `ignore-missing-licence`.
+This will ignore the tests that require an explicit license acceptance.
+
+```
+./mvnw clean install -Pall-dbs,ignore-missing-licence
+```
+
+
+If you want to run an integration tests against a different database you can do so by activating an apropriate Spring Profile.
+Available are the following Spring Profiles:
+
+`db2`, `h2`, `hsql` (default), `mariadb`, `mssql`, `mysql`, `oracle`, `postgres`
+
 === Building reference documentation
 
 Building the documentation builds also the project without running tests.

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
 
@@ -209,24 +210,40 @@
 								</configuration>
 							</execution>
 							<!--<execution>-->
-								<!--<id>mssql-test</id>-->
-								<!--<phase>test</phase>-->
-								<!--<goals>-->
-									<!--<goal>test</goal>-->
-								<!--</goals>-->
-								<!--<configuration>-->
-									<!--<includes>-->
-										<!--<include>**/*IntegrationTests.java</include>-->
-									<!--</includes>-->
-									<!--<excludes>-->
-										<!--<exclude>**/*HsqlIntegrationTests.java</exclude>-->
-									<!--</excludes>-->
-									<!--<systemPropertyVariables>-->
-										<!--<spring.profiles.active>mssql</spring.profiles.active>-->
-									<!--</systemPropertyVariables>-->
-								<!--</configuration>-->
+							<!--<id>mssql-test</id>-->
+							<!--<phase>test</phase>-->
+							<!--<goals>-->
+							<!--<goal>test</goal>-->
+							<!--</goals>-->
+							<!--<configuration>-->
+							<!--<includes>-->
+							<!--<include>**/*IntegrationTests.java</include>-->
+							<!--</includes>-->
+							<!--<excludes>-->
+							<!--<exclude>**/*HsqlIntegrationTests.java</exclude>-->
+							<!--</excludes>-->
+							<!--<systemPropertyVariables>-->
+							<!--<spring.profiles.active>mssql</spring.profiles.active>-->
+							<!--</systemPropertyVariables>-->
+							<!--</configuration>-->
 							<!--</execution>-->
 						</executions>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+		<profile>
+			<id>ignore-missing-licence</id>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-surefire-plugin</artifactId>
+						<configuration>
+							<systemPropertyVariables>
+								<on-missing-licence>ignore-test</on-missing-licence>
+							</systemPropertyVariables>
+						</configuration>
 					</plugin>
 				</plugins>
 			</build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.0-DATAJDBC-576-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.0-DATAJDBC-576-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.0-DATAJDBC-576-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.0-DATAJDBC-576-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>2.1.0-SNAPSHOT</version>
+	<version>2.1.0-DATAJDBC-576-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.1.0-SNAPSHOT</version>
+		<version>2.1.0-DATAJDBC-576-SNAPSHOT</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
Running all tests with

```
./mvnw clean install -Pall-dbs
```

or similar now requires an appropriate `container-license-acceptance.txt` to be on the classpath.

In order to ignore the tests that require an explicit license acceptance one may add the maven profile `ignore-missing-licence` like so

```
./mvnw clean install -Pall-dbs,ignore-missing-licence
```

DATAJDBC-576.