### PR TITLE
issue/DATAJDBC-353 - Fix problem with Join clause on Column with Alias

### DIFF
--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/Column.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/Column.java
@@ -32,6 +32,10 @@ public class Column extends AbstractSegment implements Expression, Named {
 	private final SqlIdentifier name;
 	private final Table table;
 
+	Column(Column column) {
+		this(column.name, column.table);
+	}
+
 	Column(String name, Table table) {
 
 		super(table);

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/DefaultSelectBuilder.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/DefaultSelectBuilder.java
@@ -320,7 +320,7 @@ class DefaultSelectBuilder implements SelectBuilder, SelectAndFrom, SelectFromAn
 		@Override
 		public SelectOnConditionComparison on(Expression column) {
 
-			this.from = column;
+			this.from = new Column((Column) column);
 			return this;
 		}
 
@@ -330,7 +330,7 @@ class DefaultSelectBuilder implements SelectBuilder, SelectAndFrom, SelectFromAn
 		 */
 		@Override
 		public JoinBuilder equals(Expression column) {
-			this.to = column;
+			this.to = new Column((Column) column);
 			return this;
 		}
 

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/render/SelectRendererUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/sql/render/SelectRendererUnitTests.java
@@ -349,4 +349,23 @@ public class SelectRendererUnitTests {
 		assertThat(rendered).isEqualTo(
 				"SELECT COUNT(\"my_table\".*) AS counter, \"my_table\".\"reserved_keyword\" FROM \"my_table\" JOIN \"join_table\" ON \"my_table\".source = \"join_table\".target");
 	}
+
+	@Test // DATAJDBC-353
+	public void shouldRenderWithColumnAlias() {
+		Table a = SQL.table("a").as("a_alias"); Column aColumn = a.column("a_col").as("a_col_alias");
+		Table b = SQL.table("b").as("b_alias"); Column bColumn = b.column("a_col").as("b_col_alias");
+
+		Select select = Select.builder().select(aColumn, bColumn)
+				.from(a)
+				.join(b).on(aColumn).equals(bColumn)
+				.build();
+
+		String target = SqlRenderer.toString(select);
+		assertThat(target)
+				.isEqualTo(
+						"SELECT a_alias.a_col AS a_col_alias, b_alias.a_col AS b_col_alias "
+								+ "FROM a a_alias "
+								+ "JOIN b b_alias ON a_alias.a_col = b_alias.a_col"
+				);
+	}
 }


### PR DESCRIPTION
The problem is that when we have a column with an alias, this alias is used in the join condition. 

When we use an alias in a join clause, we get an error; we should use the "original" column name. That is why the solution that I found here was to instead of passing forward a possible AliasColumn; we downgrade the param to Column.

I added some questions to the ticket. If my assumptions are correct, I will not need to edit my test.

For me, this is my first PR in this project. Let me know what I should change in my approach.