### PR TITLE
[JdbcQueryCreator]:Don't add joined-field twice.

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcQueryCreator.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcQueryCreator.java
@@ -235,6 +235,7 @@ class JdbcQueryCreator extends RelationalQueryCreator<ParametrizedQuery> {
 			Join join = getJoin(sqlContext, extPath);
 			if (join != null) {
 				joinTables.add(join);
+				continue;
 			}
 
 			Column column = getColumn(sqlContext, extPath);


### PR DESCRIPTION
[JdbcQueryCreator]:The join-relationship field should not be added to 'columnExpressions', It's conflicted with the joined table field. Which caused 'ResultSet contains [join-field] multiple times';