### PR TITLE
Trigger BeforeConvertEvent when saving an aggregate.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>2.2.0-SNAPSHOT</version>
+	<version>2.2.0-gh-910-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.2.0-SNAPSHOT</version>
+		<version>2.2.0-gh-910-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>2.2.0-SNAPSHOT</version>
+	<version>2.2.0-gh-910-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.2.0-SNAPSHOT</version>
+		<version>2.2.0-gh-910-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateTemplate.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/JdbcAggregateTemplate.java
@@ -404,6 +404,9 @@ public class JdbcAggregateTemplate implements JdbcAggregateOperations {
 	}
 
 	private <T> T triggerBeforeConvert(T aggregateRoot) {
+
+		publisher.publishEvent(new BeforeConvertEvent<>(aggregateRoot));
+
 		return entityCallbacks.callback(BeforeConvertCallback.class, aggregateRoot);
 	}
 

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/SimpleJdbcRepositoryEventsUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/SimpleJdbcRepositoryEventsUnitTests.java
@@ -54,6 +54,7 @@ import org.springframework.data.relational.core.mapping.RelationalMappingContext
 import org.springframework.data.relational.core.mapping.event.AfterDeleteEvent;
 import org.springframework.data.relational.core.mapping.event.AfterLoadEvent;
 import org.springframework.data.relational.core.mapping.event.AfterSaveEvent;
+import org.springframework.data.relational.core.mapping.event.BeforeConvertEvent;
 import org.springframework.data.relational.core.mapping.event.BeforeDeleteEvent;
 import org.springframework.data.relational.core.mapping.event.BeforeSaveEvent;
 import org.springframework.data.relational.core.mapping.event.Identifier;
@@ -115,6 +116,7 @@ public class SimpleJdbcRepositoryEventsUnitTests {
 		assertThat(publisher.events) //
 				.extracting(e -> (Class) e.getClass()) //
 				.containsExactly( //
+						BeforeConvertEvent.class, //
 						BeforeSaveEvent.class, //
 						AfterSaveEvent.class //
 				);
@@ -132,8 +134,10 @@ public class SimpleJdbcRepositoryEventsUnitTests {
 		assertThat(publisher.events) //
 				.extracting(e -> (Class) e.getClass()) //
 				.containsExactly( //
+						BeforeConvertEvent.class, //
 						BeforeSaveEvent.class, //
 						AfterSaveEvent.class, //
+						BeforeConvertEvent.class, //
 						BeforeSaveEvent.class, //
 						AfterSaveEvent.class //
 				);

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>2.2.0-SNAPSHOT</version>
+	<version>2.2.0-gh-910-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.2.0-SNAPSHOT</version>
+		<version>2.2.0-gh-910-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/event/BeforeConvertEvent.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/event/BeforeConvertEvent.java
@@ -23,7 +23,7 @@ import org.springframework.data.relational.core.conversion.AggregateChange;
  * @since 1.1
  * @author Jens Schauder
  */
-public class BeforeConvertEvent<E> extends RelationalSaveEvent<E> {
+public class BeforeConvertEvent<E> extends RelationalEventWithEntity<E> {
 
 	private static final long serialVersionUID = -5716795164911939224L;
 
@@ -33,7 +33,7 @@ public class BeforeConvertEvent<E> extends RelationalSaveEvent<E> {
 	 *          this event is fired before the conversion the change is actually empty, but contains information if the
 	 *          aggregate is considered new in {@link AggregateChange#getKind()}. Must not be {@literal null}.
 	 */
-	public BeforeConvertEvent(E instance, AggregateChange<E> change) {
-		super(instance, change);
+	public BeforeConvertEvent(E instance) {
+		super(instance);
 	}
 }

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/event/AbstractRelationalEventListenerUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/event/AbstractRelationalEventListenerUnitTests.java
@@ -46,7 +46,7 @@ public class AbstractRelationalEventListenerUnitTests {
 	@Test // DATAJDBC-454
 	public void beforeConvert() {
 
-		listener.onApplicationEvent(new BeforeConvertEvent<>(dummyEntity, MutableAggregateChange.forDelete(dummyEntity)));
+		listener.onApplicationEvent(new BeforeConvertEvent<>(dummyEntity));
 
 		assertThat(events).containsExactly("beforeConvert");
 	}


### PR DESCRIPTION
The event had to change its API and inheritance structure.
I'd still include it in minor releases, because it wasn't used at all before.