### PR TITLE
JdbcCustomConversion does not reject non-Date related default converters anymore

### DIFF
--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -257,6 +257,12 @@
 			<scope>test</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>org.jmolecules.integrations</groupId>
+			<artifactId>jmolecules-spring</artifactId>
+			<version>${jmolecules-integration}</version>
+			<scope>test</scope>
+		</dependency>
 
 	</dependencies>
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcCustomConversions.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcCustomConversions.java
@@ -69,14 +69,14 @@ public class JdbcCustomConversions extends CustomConversions {
 
 	private static boolean isDateTimeApiConversion(ConvertiblePair cp) {
 
-		if (cp.getSourceType().equals(java.util.Date.class) && cp.getTargetType().getTypeName().startsWith("java.time.")) {
-			return true;
+		if (cp.getSourceType().equals(java.util.Date.class)) {
+			return cp.getTargetType().getTypeName().startsWith("java.time.");
 		}
 
-		if (cp.getTargetType().equals(java.util.Date.class) && cp.getSourceType().getTypeName().startsWith("java.time.")) {
-			return true;
+		if (cp.getTargetType().equals(java.util.Date.class)) {
+			return cp.getSourceType().getTypeName().startsWith("java.time.");
 		}
 
-		return false;
+		return true;
 	}
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/JdbcCustomConversionsUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/JdbcCustomConversionsUnitTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jdbc.core.convert;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.jmolecules.ddd.types.Association;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link JdbcCustomConversions}.
+ *
+ * @author Oliver Drotbohm
+ */
+class JdbcCustomConversionsUnitTests {
+
+	@Test // #937
+	void registersNonDateDefaultConverter() {
+
+		JdbcCustomConversions conversions = new JdbcCustomConversions();
+
+		assertThat(conversions.hasCustomWriteTarget(Association.class)).isTrue();
+		assertThat(conversions.getSimpleTypeHolder().isSimpleType(Association.class));
+	}
+}


### PR DESCRIPTION
Previously, `JdbcCustomConversion` rejected any default converter that was not converting from and to `java.util.Date`. This probably stemmed from the fact that up until recently, Spring Data Commons' `CustomConversions` only registered date related default converters. As of spring-projects/spring-data-commons#2315 we also support jMolecules' `Association` and `Identifier` converters. We've relaxed the rejection to only explicitly reject all non Date/Time related converters if the conversion is from/to `java.util.Date` but allow everything else out of the box.