### PR TITLE
Move to Spring Data Commons' association abstraction.

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/BasicJdbcConverter.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/BasicJdbcConverter.java
@@ -183,7 +183,7 @@ public class BasicJdbcConverter extends BasicRelationalConverter implements Jdbc
 
 	private Class<?> doGetColumnType(RelationalPersistentProperty property) {
 
-		if (property.isReference()) {
+		if (property.isAssociation()) {
 			return getReferenceColumnType(property);
 		}
 
@@ -419,23 +419,23 @@ public class BasicJdbcConverter extends BasicRelationalConverter implements Jdbc
 			PersistentPropertyAccessor<T> propertyAccessor = getPropertyAccessor(entity, instance);
 			PreferredConstructor<T, RelationalPersistentProperty> persistenceConstructor = entity.getPersistenceConstructor();
 
-			for (RelationalPersistentProperty property : entity) {
+			entity.doWithAll(property -> {
 
 				if (persistenceConstructor != null && persistenceConstructor.isConstructorParameter(property)) {
-					continue;
+					return;
 				}
 
 				// skip absent simple properties
 				if (isSimpleProperty(property)) {
 
 					if (!propertyValueProvider.hasProperty(property)) {
-						continue;
+						return;
 					}
 				}
 
 				Object value = readOrLoadProperty(idValue, property);
 				propertyAccessor.setProperty(property, value);
-			}
+			});
 
 			return propertyAccessor.getBean();
 		}
@@ -513,7 +513,7 @@ public class BasicJdbcConverter extends BasicRelationalConverter implements Jdbc
 			for (RelationalPersistentProperty embeddedProperty : persistentEntity) {
 
 				// if the embedded contains Lists, Sets or Maps we consider it non-empty
-				if (embeddedProperty.isQualified() || embeddedProperty.isReference()) {
+				if (embeddedProperty.isQualified() || embeddedProperty.isAssociation()) {
 					return true;
 				}
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategy.java
@@ -36,7 +36,6 @@ import org.springframework.data.jdbc.support.JdbcUtil;
 import org.springframework.data.mapping.PersistentProperty;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
 import org.springframework.data.mapping.PersistentPropertyPath;
-import org.springframework.data.mapping.PropertyHandler;
 import org.springframework.data.relational.core.dialect.IdGeneration;
 import org.springframework.data.relational.core.mapping.PersistentPropertyPathExtension;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
@@ -424,7 +423,7 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 		PersistentPropertyAccessor<S> propertyAccessor = instance != null ? persistentEntity.getPropertyAccessor(instance)
 				: NoValuePropertyAccessor.instance();
 
-		persistentEntity.doWithProperties((PropertyHandler<RelationalPersistentProperty>) property -> {
+		persistentEntity.doWithAll(property -> {
 
 			if (skipProperty.test(property) || !property.isWritable()) {
 				return;

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/SqlGenerator.java
@@ -19,7 +19,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jdbc.repository.support.SimpleJdbcRepository;
 import org.springframework.data.mapping.PersistentPropertyPath;
-import org.springframework.data.mapping.PropertyHandler;
 import org.springframework.data.mapping.context.MappingContext;
 import org.springframework.data.relational.core.dialect.Dialect;
 import org.springframework.data.relational.core.dialect.RenderContextFactory;
@@ -818,7 +817,7 @@ class SqlGenerator {
 
 		private void populateColumnNameCache(RelationalPersistentEntity<?> entity, String prefix) {
 
-			entity.doWithProperties((PropertyHandler<RelationalPersistentProperty>) property -> {
+			entity.doWithAll(property -> {
 
 				// the referencing column of referenced entity is expected to be on the other side of the relation
 				if (!property.isEntity()) {

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/BasicJdbcPersistentProperty.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/BasicJdbcPersistentProperty.java
@@ -60,9 +60,21 @@ public class BasicJdbcPersistentProperty extends BasicRelationalPersistentProper
 		super(property, owner, simpleTypeHolder, namingStrategy);
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.mapping.model.AnnotationBasedPersistentProperty#isAssociation()
+	 */
 	@Override
-	public boolean isReference() {
-		return AggregateReference.class.isAssignableFrom(getRawType());
+	public boolean isAssociation() {
+		return super.isAssociation() || AggregateReference.class.isAssignableFrom(getRawType());
 	}
 
+	/*
+	 * (non-Javadoc)
+	 * @see org.springframework.data.relational.core.mapping.BasicRelationalPersistentProperty#isReference()
+	 */
+	@Override
+	public boolean isReference() {
+		return isAssociation();
+	}
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/mapping/BasicJdbcPersistentPropertyUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/mapping/BasicJdbcPersistentPropertyUnitTests.java
@@ -95,6 +95,15 @@ public class BasicJdbcPersistentPropertyUnitTests {
 		assertThat(listProperty.getReverseColumnName(path)).isEqualTo(quoted("override_id"));
 	}
 
+	@Test // #938
+	void considersAggregateReferenceAnAssociation() {
+
+		RelationalPersistentEntity<?> entity = context.getRequiredPersistentEntity(WithAssociations.class);
+		RelationalPersistentProperty property = entity.getRequiredPersistentProperty("association");
+
+		assertThat(property.isAssociation()).isTrue();
+	}
+
 	private PersistentPropertyPathExtension getPersistentPropertyPath(Class<?> type, String propertyName) {
 		PersistentPropertyPath<RelationalPersistentProperty> path = context
 				.findPersistentPropertyPaths(type, p -> p.getName().equals(propertyName)).getFirst()
@@ -148,5 +157,9 @@ public class BasicJdbcPersistentPropertyUnitTests {
 		@Column(value = "some_value") //
 		@MappedCollection(idColumn = "override_id", keyColumn = "override_key") //
 		List<Integer> overrideList;
+	}
+
+	static class WithAssociations {
+		AggregateReference<Object, Long> association;
 	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentProperty.java
@@ -124,7 +124,7 @@ public class BasicRelationalPersistentProperty extends AnnotationBasedPersistent
 	 */
 	@Override
 	protected Association<RelationalPersistentProperty> createAssociation() {
-		throw new UnsupportedOperationException();
+		return new Association<>(this, null);
 	}
 
 	public boolean isForceQuote() {
@@ -137,7 +137,7 @@ public class BasicRelationalPersistentProperty extends AnnotationBasedPersistent
 
 	@Override
 	public boolean isEntity() {
-		return super.isEntity() && !isReference();
+		return super.isEntity() && !isAssociation();
 	}
 
 	@Override

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/RelationalPersistentProperty.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/mapping/RelationalPersistentProperty.java
@@ -28,6 +28,11 @@ import org.springframework.lang.Nullable;
  */
 public interface RelationalPersistentProperty extends PersistentProperty<RelationalPersistentProperty> {
 
+	/**
+	 * @deprecated since 2.2, in favor of {@link #isAssociation()}
+	 * @return
+	 */
+	@Deprecated
 	boolean isReference();
 
 	/**


### PR DESCRIPTION
Deprecated Spring Data JDBC's custom `PersistentProperty.isReference()` in favor of the already existing `….isAssociation()` with the same semantics to benefit from association definitions implemented in Spring Data Commons. Make use of the newly introduced `PersistentEntity.doWithAll(…)` to apply the previously existing property handling to both properties and now associations, too.