### PR TITLE
Add support for `Slice` and `Page` queries using query derivation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>2.2.0-SNAPSHOT</version>
+	<version>2.2.0-GH-774-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.2.0-SNAPSHOT</version>
+		<version>2.2.0-GH-774-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>2.2.0-SNAPSHOT</version>
+	<version>2.2.0-GH-774-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.2.0-SNAPSHOT</version>
+		<version>2.2.0-GH-774-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/AbstractJdbcQuery.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/AbstractJdbcQuery.java
@@ -108,7 +108,7 @@ public abstract class AbstractJdbcQuery implements RepositoryQuery {
 		};
 	}
 
-	private JdbcQueryExecution<Object> singleObjectQuery(RowMapper<?> rowMapper) {
+	JdbcQueryExecution<Object> singleObjectQuery(RowMapper<?> rowMapper) {
 
 		return (query, parameters) -> {
 			try {
@@ -119,7 +119,7 @@ public abstract class AbstractJdbcQuery implements RepositoryQuery {
 		};
 	}
 
-	private <T> JdbcQueryExecution<List<T>> collectionQuery(RowMapper<T> rowMapper) {
+	<T> JdbcQueryExecution<List<T>> collectionQuery(RowMapper<T> rowMapper) {
 		return getQueryExecution(new RowMapperResultSetExtractor<>(rowMapper));
 	}
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcCountQueryCreator.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcCountQueryCreator.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jdbc.repository.query;
+
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jdbc.core.convert.JdbcConverter;
+import org.springframework.data.relational.core.dialect.Dialect;
+import org.springframework.data.relational.core.mapping.RelationalMappingContext;
+import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
+import org.springframework.data.relational.core.sql.Expressions;
+import org.springframework.data.relational.core.sql.Functions;
+import org.springframework.data.relational.core.sql.Select;
+import org.springframework.data.relational.core.sql.SelectBuilder;
+import org.springframework.data.relational.core.sql.Table;
+import org.springframework.data.relational.repository.query.RelationalEntityMetadata;
+import org.springframework.data.relational.repository.query.RelationalParameterAccessor;
+import org.springframework.data.repository.query.parser.PartTree;
+
+/**
+ * {@link JdbcQueryCreator} that creates {@code COUNT(*)} queries without applying limit/offset and {@link Sort}.
+ *
+ * @author Mark Paluch
+ * @since 2.2
+ */
+class JdbcCountQueryCreator extends JdbcQueryCreator {
+
+	JdbcCountQueryCreator(RelationalMappingContext context, PartTree tree, JdbcConverter converter, Dialect dialect,
+			RelationalEntityMetadata<?> entityMetadata, RelationalParameterAccessor accessor, boolean isSliceQuery) {
+		super(context, tree, converter, dialect, entityMetadata, accessor, isSliceQuery);
+	}
+
+	@Override
+	SelectBuilder.SelectOrdered applyOrderBy(Sort sort, RelationalPersistentEntity<?> entity, Table table,
+			SelectBuilder.SelectOrdered selectOrdered) {
+		return selectOrdered;
+	}
+
+	@Override
+	SelectBuilder.SelectWhere applyLimitAndOffset(SelectBuilder.SelectLimitOffset limitOffsetBuilder) {
+		return (SelectBuilder.SelectWhere) limitOffsetBuilder;
+	}
+
+	@Override
+	SelectBuilder.SelectLimitOffset createSelectClause(RelationalPersistentEntity<?> entity, Table table) {
+		return Select.builder().select(Functions.count(Expressions.asterisk())).from(table);
+	}
+}

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/PartTreeJdbcQuery.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/PartTreeJdbcQuery.java
@@ -16,7 +16,14 @@
 package org.springframework.data.jdbc.repository.query;
 
 import java.sql.ResultSet;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.LongSupplier;
 
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jdbc.core.convert.JdbcConverter;
 import org.springframework.data.relational.core.dialect.Dialect;
@@ -26,9 +33,11 @@ import org.springframework.data.relational.repository.query.RelationalParameterA
 import org.springframework.data.relational.repository.query.RelationalParametersParameterAccessor;
 import org.springframework.data.repository.query.Parameters;
 import org.springframework.data.repository.query.parser.PartTree;
+import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.util.Assert;
 
 /**
@@ -46,6 +55,7 @@ public class PartTreeJdbcQuery extends AbstractJdbcQuery {
 	private final JdbcConverter converter;
 	private final PartTree tree;
 	private final JdbcQueryExecution<?> execution;
+	private final RowMapper<Object> rowMapper;
 
 	/**
 	 * Creates a new {@link PartTreeJdbcQuery}.
@@ -77,7 +87,9 @@ public class PartTreeJdbcQuery extends AbstractJdbcQuery {
 
 		ResultSetExtractor<Boolean> extractor = tree.isExistsProjection() ? (ResultSet::next) : null;
 
-		this.execution = getQueryExecution(queryMethod, extractor, rowMapper);
+		this.execution = queryMethod.isPageQuery() || queryMethod.isSliceQuery() ? collectionQuery(rowMapper)
+				: getQueryExecution(queryMethod, extractor, rowMapper);
+		this.rowMapper = rowMapper;
 	}
 
 	private Sort getDynamicSort(RelationalParameterAccessor accessor) {
@@ -93,15 +105,108 @@ public class PartTreeJdbcQuery extends AbstractJdbcQuery {
 
 		RelationalParametersParameterAccessor accessor = new RelationalParametersParameterAccessor(getQueryMethod(),
 				values);
-
 		ParametrizedQuery query = createQuery(accessor);
-		return this.execution.execute(query.getQuery(), query.getParameterSource());
+		JdbcQueryExecution<?> execution = getQueryExecution(accessor);
+
+		return execution.execute(query.getQuery(), query.getParameterSource());
+	}
+
+	private JdbcQueryExecution<?> getQueryExecution(RelationalParametersParameterAccessor accessor) {
+
+		if (getQueryMethod().isSliceQuery()) {
+			return new SliceQueryExecution<>((JdbcQueryExecution<Collection<Object>>) this.execution, accessor.getPageable());
+		}
+
+		if (getQueryMethod().isPageQuery()) {
+
+			return new PageQueryExecution<>((JdbcQueryExecution<Collection<Object>>) this.execution, accessor.getPageable(),
+					() -> {
+
+						RelationalEntityMetadata<?> entityMetadata = getQueryMethod().getEntityInformation();
+
+						JdbcCountQueryCreator queryCreator = new JdbcCountQueryCreator(context, tree, converter, dialect,
+								entityMetadata, accessor, false);
+
+						ParametrizedQuery countQuery = queryCreator.createQuery(Sort.unsorted());
+						Object count = singleObjectQuery((rs, i) -> rs.getLong(1)).execute(countQuery.getQuery(),
+								countQuery.getParameterSource());
+
+						return converter.getConversionService().convert(count, Long.class);
+					});
+		}
+
+		return this.execution;
 	}
 
 	protected ParametrizedQuery createQuery(RelationalParametersParameterAccessor accessor) {
 
 		RelationalEntityMetadata<?> entityMetadata = getQueryMethod().getEntityInformation();
-		JdbcQueryCreator queryCreator = new JdbcQueryCreator(context, tree, converter, dialect, entityMetadata, accessor);
+
+		JdbcQueryCreator queryCreator = new JdbcQueryCreator(context, tree, converter, dialect, entityMetadata, accessor,
+				getQueryMethod().isSliceQuery());
 		return queryCreator.createQuery(getDynamicSort(accessor));
+	}
+
+	/**
+	 * {@link JdbcQueryExecution} returning a {@link org.springframework.data.domain.Slice}.
+	 *
+	 * @param <T>
+	 */
+	static class SliceQueryExecution<T> implements JdbcQueryExecution<Slice<T>> {
+
+		private final JdbcQueryExecution<? extends Collection<T>> delegate;
+		private final Pageable pageable;
+
+		public SliceQueryExecution(JdbcQueryExecution<? extends Collection<T>> delegate, Pageable pageable) {
+			this.delegate = delegate;
+			this.pageable = pageable;
+		}
+
+		@Override
+		public Slice<T> execute(String query, SqlParameterSource parameter) {
+
+			Collection<T> result = delegate.execute(query, parameter);
+
+			int pageSize = 0;
+			if (pageable.isPaged()) {
+
+				pageSize = pageable.getPageSize();
+			}
+
+			List<T> resultList = result instanceof List ? (List<T>) result : new ArrayList<>(result);
+
+			boolean hasNext = pageable.isPaged() && resultList.size() > pageSize;
+
+			return new SliceImpl<>(hasNext ? resultList.subList(0, pageSize) : resultList, pageable, hasNext);
+		}
+	}
+
+	/**
+	 * {@link JdbcQueryExecution} returning a {@link org.springframework.data.domain.Page}.
+	 *
+	 * @param <T>
+	 */
+	static class PageQueryExecution<T> implements JdbcQueryExecution<Slice<T>> {
+
+		private final JdbcQueryExecution<? extends Collection<T>> delegate;
+		private final Pageable pageable;
+		private final LongSupplier countSupplier;
+
+		public PageQueryExecution(JdbcQueryExecution<? extends Collection<T>> delegate, Pageable pageable,
+				LongSupplier countSupplier) {
+			this.delegate = delegate;
+			this.pageable = pageable;
+			this.countSupplier = countSupplier;
+		}
+
+		@Override
+		public Slice<T> execute(String query, SqlParameterSource parameter) {
+
+			Collection<T> result = delegate.execute(query, parameter);
+
+			return PageableExecutionUtils.getPage(result instanceof List ? (List<T>) result : new ArrayList<>(result),
+					pageable, countSupplier);
+		}
+
 	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQuery.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQuery.java
@@ -73,6 +73,16 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 		this.queryMethod = queryMethod;
 		this.converter = converter;
 
+		if (queryMethod.isSliceQuery()) {
+			throw new UnsupportedOperationException(
+					"Slice queries are not supported using string-based queries. Offending method: " + queryMethod);
+		}
+
+		if (queryMethod.isPageQuery()) {
+			throw new UnsupportedOperationException(
+					"Page queries are not supported using string-based queries. Offending method: " + queryMethod);
+		}
+
 		executor = Lazy.of(() -> {
 			RowMapper<Object> rowMapper = determineRowMapper(defaultRowMapper);
 			return getQueryExecution( //

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCrossAggregateHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryCrossAggregateHsqlIntegrationTests.java
@@ -21,7 +21,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.core.mapping.AggregateReference;
@@ -55,7 +57,8 @@ public class JdbcRepositoryCrossAggregateHsqlIntegrationTests {
 
 	@Configuration
 	@Import(TestConfiguration.class)
-	@EnableJdbcRepositories(considerNestedRepositories = true)
+	@EnableJdbcRepositories(considerNestedRepositories = true,
+			includeFilters = @ComponentScan.Filter(value = Ones.class, type = FilterType.ASSIGNABLE_TYPE))
 	static class Config {
 
 		@Autowired JdbcRepositoryFactory factory;

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryIdGenerationIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/JdbcRepositoryIdGenerationIntegrationTests.java
@@ -26,10 +26,12 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
@@ -141,7 +143,8 @@ public class JdbcRepositoryIdGenerationIntegrationTests {
 
 	@Configuration
 	@ComponentScan("org.springframework.data.jdbc.testing")
-	@EnableJdbcRepositories(considerNestedRepositories = true)
+	@EnableJdbcRepositories(considerNestedRepositories = true,
+			includeFilters = @ComponentScan.Filter(value = CrudRepository.class, type = FilterType.ASSIGNABLE_TYPE))
 	static class TestConfiguration {
 
 		AtomicLong lastId = new AtomicLong(0);

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/StringBasedJdbcQueryMappingConfigurationIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/StringBasedJdbcQueryMappingConfigurationIntegrationTests.java
@@ -28,13 +28,15 @@ import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.jdbc.core.convert.EntityRowMapper;
 import org.springframework.data.jdbc.repository.config.DefaultQueryMappingConfiguration;
 import org.springframework.data.jdbc.repository.config.EnableJdbcRepositories;
 import org.springframework.data.jdbc.repository.query.Query;
@@ -63,7 +65,8 @@ public class StringBasedJdbcQueryMappingConfigurationIntegrationTests {
 
 	@Configuration
 	@Import(TestConfiguration.class)
-	@EnableJdbcRepositories(considerNestedRepositories = true)
+	@EnableJdbcRepositories(considerNestedRepositories = true,
+			includeFilters = @ComponentScan.Filter(value = CarRepository.class, type = FilterType.ASSIGNABLE_TYPE))
 	static class Config {
 
 		@Bean

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/QueryAnnotationHsqlIntegrationTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/QueryAnnotationHsqlIntegrationTests.java
@@ -30,7 +30,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.dao.DataAccessException;
 import org.springframework.data.annotation.Id;
@@ -57,7 +59,8 @@ public class QueryAnnotationHsqlIntegrationTests {
 
 	@Configuration
 	@Import(TestConfiguration.class)
-	@EnableJdbcRepositories(considerNestedRepositories = true)
+	@EnableJdbcRepositories(considerNestedRepositories = true,
+			includeFilters = @ComponentScan.Filter(value = DummyEntityRepository.class, type = FilterType.ASSIGNABLE_TYPE))
 	static class Config {
 
 		@Bean

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>2.2.0-SNAPSHOT</version>
+	<version>2.2.0-GH-774-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.2.0-SNAPSHOT</version>
+		<version>2.2.0-GH-774-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/src/main/asciidoc/jdbc.adoc
+++ b/src/main/asciidoc/jdbc.adoc
@@ -491,22 +491,28 @@ interface PersonRepository extends PagingAndSortingRepository<Person, String> {
 
   List<Person> findByFirstnameOrderByLastname(String firstname, Pageable pageable); <2>
 
-  Person findByFirstnameAndLastname(String firstname, String lastname);             <3>
+  Slice<Person> findByLastname(String lastname, Pageable pageable);                 <3>
 
-  Person findFirstByLastname(String lastname);                                      <4>
+  Page<Person> findByLastname(String lastname, Pageable pageable);                  <4>
+
+  Person findByFirstnameAndLastname(String firstname, String lastname);             <5>
+
+  Person findFirstByLastname(String lastname);                                      <6>
 
   @Query("SELECT * FROM person WHERE lastname = :lastname")
-  List<Person> findByLastname(String lastname);                                     <5>
+  List<Person> findByLastname(String lastname);                                     <7>
 }
 ----
 <1> The method shows a query for all people with the given `lastname`.
 The query is derived by parsing the method name for constraints that can be concatenated with `And` and `Or`.
 Thus, the method name results in a query expression of `SELECT … FROM person WHERE firstname = :firstname`.
 <2> Use `Pageable` to pass offset and sorting parameters to the database.
-<3> Find a single entity for the given criteria.
+<3> Return a `Slice<Person>`. Selects `LIMIT+1` rows to determine whether there's more data to consume. `ResultSetExtractor` customization is not supported.
+<4> Run a paginated query returning `Page<Person>`. Selects only data within the given page bounds and potentially a count query to determine the total count. `ResultSetExtractor` customization is not supported.
+<5> Find a single entity for the given criteria.
 It completes with `IncorrectResultSizeDataAccessException` on non-unique results.
-<4> In contrast to <3>, the first entity is always emitted even if the query yields more result documents.
-<5> The `findByLastname` method shows a query for all people with the given last name.
+<6> In contrast to <3>, the first entity is always emitted even if the query yields more result documents.
+<7> The `findByLastname` method shows a query for all people with the given last name.
 ====
 
 The following table shows the keywords that are supported for query methods:

--- a/src/main/asciidoc/new-features.adoc
+++ b/src/main/asciidoc/new-features.adoc
@@ -3,6 +3,9 @@
 
 This section covers the significant changes for each version.
 
+[[new-features.2-2-0]]
+== `Page` and `Slice` support for <<jdbc.query-methods,derived queries>>.
+
 [[new-features.2-1-0]]
 == What's New in Spring Data JDBC 2.1
 


### PR DESCRIPTION
We now support pagination for queries returning `Slice` and `Page`.

```
interface PersonRepository extends PagingAndSortingRepository<Person, String> {

  Slice<Person> findFirstByLastname(String lastname, Pageable pageable);

  Page<Person> findFirstByLastname(String lastname, Pageable pageable);
}
```

Closes #774