### PR TITLE
Fixes build failures with JDK16.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>2.3.0-SNAPSHOT</version>
+	<version>2.3.0-fix-jdk16-failures-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.3.0-SNAPSHOT</version>
+		<version>2.3.0-fix-jdk16-failures-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>2.3.0-SNAPSHOT</version>
+	<version>2.3.0-fix-jdk16-failures-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.3.0-SNAPSHOT</version>
+		<version>2.3.0-fix-jdk16-failures-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/JdbcMappingContext.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/JdbcMappingContext.java
@@ -46,6 +46,7 @@ public class JdbcMappingContext extends RelationalMappingContext {
 	 */
 	public JdbcMappingContext() {
 		super();
+		setSimpleTypeHolder(JdbcSimpleTypes.HOLDER);
 	}
 
 	/**
@@ -55,6 +56,7 @@ public class JdbcMappingContext extends RelationalMappingContext {
 	 */
 	public JdbcMappingContext(NamingStrategy namingStrategy) {
 		super(namingStrategy);
+		setSimpleTypeHolder(JdbcSimpleTypes.HOLDER);
 	}
 
 	/*

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/AbstractJdbcConfiguration.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/AbstractJdbcConfiguration.java
@@ -63,7 +63,10 @@ public class AbstractJdbcConfiguration {
 	public JdbcMappingContext jdbcMappingContext(Optional<NamingStrategy> namingStrategy,
 			JdbcCustomConversions customConversions) {
 
-		return new JdbcMappingContext(namingStrategy.orElse(NamingStrategy.INSTANCE));
+		JdbcMappingContext mappingContext = new JdbcMappingContext(namingStrategy.orElse(NamingStrategy.INSTANCE));
+		mappingContext.setSimpleTypeHolder(customConversions.getSimpleTypeHolder());
+
+		return mappingContext;
 	}
 
 	/**

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/AbstractJdbcConfiguration.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/config/AbstractJdbcConfiguration.java
@@ -63,10 +63,7 @@ public class AbstractJdbcConfiguration {
 	public JdbcMappingContext jdbcMappingContext(Optional<NamingStrategy> namingStrategy,
 			JdbcCustomConversions customConversions) {
 
-		JdbcMappingContext mappingContext = new JdbcMappingContext(namingStrategy.orElse(NamingStrategy.INSTANCE));
-		mappingContext.setSimpleTypeHolder(customConversions.getSimpleTypeHolder());
-
-		return mappingContext;
+		return new JdbcMappingContext(namingStrategy.orElse(NamingStrategy.INSTANCE));
 	}
 
 	/**

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MariaDBDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MariaDBDataSourceConfiguration.java
@@ -50,9 +50,7 @@ class MariaDBDataSourceConfiguration extends DataSourceConfiguration implements 
 
 		if (MARIADB_CONTAINER == null) {
 
-			MariaDBContainer<?> container = new MariaDBContainer<>("mariadb:10.5")
-					.withUsername("root")
-					.withPassword("")
+			MariaDBContainer<?> container = new MariaDBContainer<>("mariadb:10.5").withUsername("root").withPassword("")
 					.withConfigurationOverride("");
 			container.start();
 
@@ -79,5 +77,4 @@ class MariaDBDataSourceConfiguration extends DataSourceConfiguration implements 
 					new ByteArrayResource("DROP DATABASE test;CREATE DATABASE test;".getBytes()));
 		}
 	}
-
 }

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MariaDBDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MariaDBDataSourceConfiguration.java
@@ -18,10 +18,10 @@ package org.springframework.data.jdbc.testing;
 import java.sql.Connection;
 import java.sql.SQLException;
 
-import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
 
 import org.mariadb.jdbc.MariaDbDataSource;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ByteArrayResource;
@@ -33,10 +33,11 @@ import org.testcontainers.containers.MariaDBContainer;
  *
  * @author Christoph Preißner
  * @author Mark Paluch
+ * @author Jens Schauder
  */
 @Configuration
 @Profile("mariadb")
-class MariaDBDataSourceConfiguration extends DataSourceConfiguration {
+class MariaDBDataSourceConfiguration extends DataSourceConfiguration implements InitializingBean {
 
 	private static MariaDBContainer<?> MARIADB_CONTAINER;
 
@@ -70,8 +71,8 @@ class MariaDBDataSourceConfiguration extends DataSourceConfiguration {
 		}
 	}
 
-	@PostConstruct
-	public void initDatabase() throws SQLException {
+	@Override
+	public void afterPropertiesSet() throws Exception {
 
 		try (Connection connection = createDataSource().getConnection()) {
 			ScriptUtils.executeSqlScript(connection,

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MySqlDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MySqlDataSourceConfiguration.java
@@ -52,9 +52,7 @@ class MySqlDataSourceConfiguration extends DataSourceConfiguration implements In
 
 		if (MYSQL_CONTAINER == null) {
 
-			MySQLContainer<?> container = new MySQLContainer<>("mysql:8.0.24")
-					.withUsername("test")
-					.withPassword("test")
+			MySQLContainer<?> container = new MySQLContainer<>("mysql:8.0.24").withUsername("test").withPassword("test")
 					.withConfigurationOverride("");
 
 			container.start();

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MySqlDataSourceConfiguration.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/testing/MySqlDataSourceConfiguration.java
@@ -16,17 +16,17 @@
 package org.springframework.data.jdbc.testing;
 
 import java.sql.Connection;
-import java.sql.SQLException;
 
-import javax.annotation.PostConstruct;
 import javax.sql.DataSource;
 
-import com.mysql.cj.jdbc.MysqlDataSource;
+import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ByteArrayResource;
 import org.springframework.jdbc.datasource.init.ScriptUtils;
 import org.testcontainers.containers.MySQLContainer;
+
+import com.mysql.cj.jdbc.MysqlDataSource;
 
 /**
  * {@link DataSource} setup for MySQL. Starts a docker container with a MySql database and sets up a database name
@@ -39,7 +39,7 @@ import org.testcontainers.containers.MySQLContainer;
  */
 @Configuration
 @Profile("mysql")
-class MySqlDataSourceConfiguration extends DataSourceConfiguration {
+class MySqlDataSourceConfiguration extends DataSourceConfiguration implements InitializingBean {
 
 	private static MySQLContainer<?> MYSQL_CONTAINER;
 
@@ -71,8 +71,8 @@ class MySqlDataSourceConfiguration extends DataSourceConfiguration {
 		return dataSource;
 	}
 
-	@PostConstruct
-	public void initDatabase() throws SQLException {
+	@Override
+	public void afterPropertiesSet() throws Exception {
 
 		try (Connection connection = createDataSource().getConnection()) {
 			ScriptUtils.executeSqlScript(connection,

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>2.3.0-SNAPSHOT</version>
+	<version>2.3.0-fix-jdk16-failures-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.3.0-SNAPSHOT</version>
+		<version>2.3.0-fix-jdk16-failures-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentPropertyUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentPropertyUnitTests.java
@@ -59,9 +59,12 @@ public class BasicRelationalPersistentPropertyUnitTests {
 
 		RelationalPersistentProperty listProperty = entity.getRequiredPersistentProperty("someList");
 
-		PersistentPropertyPath<RelationalPersistentProperty> path = context.findPersistentPropertyPaths(DummyEntity.class, p -> p.getName().equals("someList")).getFirst().orElseThrow(() -> new AssertionFailedError("Couldn't find path for 'someList'"));
+		PersistentPropertyPath<RelationalPersistentProperty> path = context
+				.findPersistentPropertyPaths(DummyEntity.class, p -> p.getName().equals("someList")).getFirst()
+				.orElseThrow(() -> new AssertionFailedError("Couldn't find path for 'someList'"));
 
-		assertThat(listProperty.getReverseColumnName(new PersistentPropertyPathExtension(context, path))).isEqualTo(quoted("dummy_column_name"));
+		assertThat(listProperty.getReverseColumnName(new PersistentPropertyPathExtension(context, path)))
+				.isEqualTo(quoted("dummy_column_name"));
 		assertThat(listProperty.getKeyColumn()).isEqualTo(quoted("dummy_key_column_name"));
 	}
 

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentPropertyUnitTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/core/mapping/BasicRelationalPersistentPropertyUnitTests.java
@@ -25,7 +25,6 @@ import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import java.util.List;
-import java.util.UUID;
 import java.util.function.BiConsumer;
 
 import org.assertj.core.api.SoftAssertions;
@@ -46,7 +45,6 @@ public class BasicRelationalPersistentPropertyUnitTests {
 
 	RelationalMappingContext context = new RelationalMappingContext();
 	RelationalPersistentEntity<?> entity = context.getRequiredPersistentEntity(DummyEntity.class);
-
 
 	@Test // DATAJDBC-106
 	public void detectsAnnotatedColumnName() {
@@ -127,7 +125,6 @@ public class BasicRelationalPersistentPropertyUnitTests {
 		softly.assertAll();
 	}
 
-
 	@Data
 	@SuppressWarnings("unused")
 	private static class DummyEntity {
@@ -136,7 +133,6 @@ public class BasicRelationalPersistentPropertyUnitTests {
 		private final SomeEnum someEnum;
 		private final LocalDateTime localDateTime;
 		private final ZonedDateTime zonedDateTime;
-		private final UUID uuid;
 
 		// DATAJDBC-259
 		private final List<String> listOfString;


### PR DESCRIPTION
`JdbcMappingContext` sets the SimpleTypeHolder to `JdbcSimpleTypeHolder.HOLDER` by default.
Fixing test failures where properties of type `UUID` were considered an entity by the `MappingContext`.
This in turn triggered failures when it tried to make fields of `UUID` accessible.

Removed the `UUID` field from a test entity in SD Relational, since `UUID` is not a simple type for Relational, nor a proper entity.

Replaced `@PostConstruct` with `InitializingBean` in test data source conifgurations in order avoid the requirement of importing javax.annotation-api.