### PR TITLE
Add support for repository query method projections

### DIFF
--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/AbstractJdbcQuery.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/AbstractJdbcQuery.java
@@ -15,10 +15,15 @@
  */
 package org.springframework.data.jdbc.repository.query;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.List;
 
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.data.repository.query.RepositoryQuery;
+import org.springframework.data.repository.query.ResultProcessor;
+import org.springframework.data.repository.query.ReturnedType;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.RowMapperResultSetExtractor;
@@ -43,22 +48,16 @@ public abstract class AbstractJdbcQuery implements RepositoryQuery {
 	private final NamedParameterJdbcOperations operations;
 
 	/**
-	 * Creates a new {@link AbstractJdbcQuery} for the given {@link JdbcQueryMethod}, {@link NamedParameterJdbcOperations}
-	 * and {@link RowMapper}.
+	 * Creates a new {@link AbstractJdbcQuery} for the given {@link JdbcQueryMethod} and
+	 * {@link NamedParameterJdbcOperations}.
 	 *
 	 * @param queryMethod must not be {@literal null}.
 	 * @param operations must not be {@literal null}.
-	 * @param defaultRowMapper can be {@literal null} (only in case of a modifying query).
 	 */
-	AbstractJdbcQuery(JdbcQueryMethod queryMethod, NamedParameterJdbcOperations operations,
-			@Nullable RowMapper<?> defaultRowMapper) {
+	AbstractJdbcQuery(JdbcQueryMethod queryMethod, NamedParameterJdbcOperations operations) {
 
 		Assert.notNull(queryMethod, "Query method must not be null!");
 		Assert.notNull(operations, "NamedParameterJdbcOperations must not be null!");
-
-		if (!queryMethod.isModifyingQuery()) {
-			Assert.notNull(defaultRowMapper, "Mapper must not be null!");
-		}
 
 		this.queryMethod = queryMethod;
 		this.operations = operations;
@@ -123,8 +122,59 @@ public abstract class AbstractJdbcQuery implements RepositoryQuery {
 		return getQueryExecution(new RowMapperResultSetExtractor<>(rowMapper));
 	}
 
+	/**
+	 * Obtain the result type to read from {@link ResultProcessor}.
+	 *
+	 * @param resultProcessor
+	 * @return
+	 */
+	protected Class<?> resolveTypeToRead(ResultProcessor resultProcessor) {
+
+		ReturnedType returnedType = resultProcessor.getReturnedType();
+
+		if (returnedType.getReturnedType().isAssignableFrom(returnedType.getDomainType())) {
+			return returnedType.getDomainType();
+		}
+		// Slight deviation from R2DBC: Allow direct mapping into DTOs
+		return returnedType.isProjecting() && returnedType.getReturnedType().isInterface() ? returnedType.getDomainType()
+				: returnedType.getReturnedType();
+	}
+
 	private <T> JdbcQueryExecution<T> getQueryExecution(ResultSetExtractor<T> resultSetExtractor) {
 		return (query, parameters) -> operations.query(query, parameters, resultSetExtractor);
 	}
 
+	/**
+	 * Factory to create a {@link RowMapper} for a given class.
+	 *
+	 * @since 2.3
+	 */
+	public interface RowMapperFactory {
+		RowMapper<Object> create(Class<?> result);
+	}
+
+	/**
+	 * Delegating {@link RowMapper} that reads a row into {@code T} and converts it afterwards into {@code Object}.
+	 *
+	 * @param <T>
+	 * @since 2.3
+	 */
+	protected static class ConvertingRowMapper<T> implements RowMapper<Object> {
+
+		private final RowMapper<T> delegate;
+		private final Converter<Object, Object> converter;
+
+		public ConvertingRowMapper(RowMapper<T> delegate, Converter<Object, Object> converter) {
+			this.delegate = delegate;
+			this.converter = converter;
+		}
+
+		@Override
+		public Object mapRow(ResultSet rs, int rowNum) throws SQLException {
+
+			T object = delegate.mapRow(rs, rowNum);
+
+			return converter.convert(object);
+		}
+	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcCountQueryCreator.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/JdbcCountQueryCreator.java
@@ -27,6 +27,7 @@ import org.springframework.data.relational.core.sql.SelectBuilder;
 import org.springframework.data.relational.core.sql.Table;
 import org.springframework.data.relational.repository.query.RelationalEntityMetadata;
 import org.springframework.data.relational.repository.query.RelationalParameterAccessor;
+import org.springframework.data.repository.query.ReturnedType;
 import org.springframework.data.repository.query.parser.PartTree;
 
 /**
@@ -38,8 +39,9 @@ import org.springframework.data.repository.query.parser.PartTree;
 class JdbcCountQueryCreator extends JdbcQueryCreator {
 
 	JdbcCountQueryCreator(RelationalMappingContext context, PartTree tree, JdbcConverter converter, Dialect dialect,
-			RelationalEntityMetadata<?> entityMetadata, RelationalParameterAccessor accessor, boolean isSliceQuery) {
-		super(context, tree, converter, dialect, entityMetadata, accessor, isSliceQuery);
+			RelationalEntityMetadata<?> entityMetadata, RelationalParameterAccessor accessor, boolean isSliceQuery,
+			ReturnedType returnedType) {
+		super(context, tree, converter, dialect, entityMetadata, accessor, isSliceQuery, returnedType);
 	}
 
 	@Override

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQuery.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQuery.java
@@ -15,18 +15,24 @@
  */
 package org.springframework.data.jdbc.repository.query;
 
+import static org.springframework.data.jdbc.repository.query.JdbcQueryExecution.*;
+
 import java.lang.reflect.Constructor;
 import java.sql.JDBCType;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.core.convert.converter.Converter;
 import org.springframework.data.jdbc.core.convert.JdbcColumnTypes;
 import org.springframework.data.jdbc.core.convert.JdbcConverter;
 import org.springframework.data.jdbc.core.convert.JdbcValue;
 import org.springframework.data.jdbc.support.JdbcUtil;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
+import org.springframework.data.relational.repository.query.RelationalParameterAccessor;
+import org.springframework.data.relational.repository.query.RelationalParametersParameterAccessor;
 import org.springframework.data.repository.query.Parameter;
-import org.springframework.data.util.Lazy;
+import org.springframework.data.repository.query.Parameters;
+import org.springframework.data.repository.query.ResultProcessor;
 import org.springframework.jdbc.core.ResultSetExtractor;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
@@ -53,8 +59,8 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 	private static final String PARAMETER_NEEDS_TO_BE_NAMED = "For queries with named parameters you need to provide names for method parameters. Use @Param for query method parameters, or when on Java 8+ use the javac flag -parameters.";
 
 	private final JdbcQueryMethod queryMethod;
-	private final Lazy<JdbcQueryExecution<?>> executor;
 	private final JdbcConverter converter;
+	private final RowMapperFactory rowMapperFactory;
 	private BeanFactory beanFactory;
 
 	/**
@@ -67,11 +73,28 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 	 */
 	public StringBasedJdbcQuery(JdbcQueryMethod queryMethod, NamedParameterJdbcOperations operations,
 			@Nullable RowMapper<?> defaultRowMapper, JdbcConverter converter) {
+		this(queryMethod, operations, result -> (RowMapper<Object>) defaultRowMapper, converter);
+	}
 
-		super(queryMethod, operations, defaultRowMapper);
+	/**
+	 * Creates a new {@link StringBasedJdbcQuery} for the given {@link JdbcQueryMethod}, {@link RelationalMappingContext}
+	 * and {@link RowMapperFactory}.
+	 *
+	 * @param queryMethod must not be {@literal null}.
+	 * @param operations must not be {@literal null}.
+	 * @param rowMapperFactory must not be {@literal null}.
+	 * @since 2.3
+	 */
+	public StringBasedJdbcQuery(JdbcQueryMethod queryMethod, NamedParameterJdbcOperations operations,
+			RowMapperFactory rowMapperFactory, JdbcConverter converter) {
+
+		super(queryMethod, operations);
+
+		Assert.notNull(rowMapperFactory, "RowMapperFactory must not be null");
 
 		this.queryMethod = queryMethod;
 		this.converter = converter;
+		this.rowMapperFactory = rowMapperFactory;
 
 		if (queryMethod.isSliceQuery()) {
 			throw new UnsupportedOperationException(
@@ -82,14 +105,6 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 			throw new UnsupportedOperationException(
 					"Page queries are not supported using string-based queries. Offending method: " + queryMethod);
 		}
-
-		executor = Lazy.of(() -> {
-			RowMapper<Object> rowMapper = determineRowMapper(defaultRowMapper);
-			return getQueryExecution( //
-				queryMethod, //
-				determineResultSetExtractor(rowMapper), //
-				rowMapper //
-		);});
 	}
 
 	/*
@@ -98,7 +113,21 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 	 */
 	@Override
 	public Object execute(Object[] objects) {
-		return executor.get().execute(determineQuery(), this.bindParameters(objects));
+
+		RelationalParameterAccessor accessor = new RelationalParametersParameterAccessor(getQueryMethod(), objects);
+		ResultProcessor processor = getQueryMethod().getResultProcessor().withDynamicProjection(accessor);
+		ResultProcessingConverter converter = new ResultProcessingConverter(processor, this.converter.getMappingContext(),
+				this.converter.getEntityInstantiators());
+
+		RowMapper<Object> rowMapper = determineRowMapper(rowMapperFactory.create(resolveTypeToRead(processor)), converter,
+				accessor.findDynamicProjection() != null);
+
+		JdbcQueryExecution<?> queryExecution = getQueryExecution(//
+				queryMethod, //
+				determineResultSetExtractor(rowMapper), //
+				rowMapper);
+
+		return queryExecution.execute(determineQuery(), this.bindParameters(accessor));
 	}
 
 	/*
@@ -110,12 +139,15 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 		return queryMethod;
 	}
 
-	private MapSqlParameterSource bindParameters(Object[] objects) {
+	private MapSqlParameterSource bindParameters(RelationalParameterAccessor accessor) {
 
 		MapSqlParameterSource parameters = new MapSqlParameterSource();
 
-		queryMethod.getParameters().getBindableParameters()
-				.forEach(p -> convertAndAddParameter(parameters, p, objects[p.getIndex()]));
+		Parameters<?, ?> bindableParameters = accessor.getBindableParameters();
+
+		for (Parameter bindableParameter : bindableParameters) {
+			convertAndAddParameter(parameters, bindableParameter, accessor.getBindableValue(bindableParameter.getIndex()));
+		}
 
 		return parameters;
 	}
@@ -177,6 +209,19 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 		}
 
 		return BeanUtils.instantiateClass(resultSetExtractorClass);
+	}
+
+	@Nullable
+	RowMapper<Object> determineRowMapper(@Nullable RowMapper<?> defaultMapper,
+			Converter<Object, Object> resultProcessingConverter, boolean hasDynamicProjection) {
+
+		RowMapper<Object> rowMapperToUse = determineRowMapper(defaultMapper);
+
+		if ((hasDynamicProjection || rowMapperToUse == defaultMapper) && rowMapperToUse != null) {
+			return new ConvertingRowMapper<>(rowMapperToUse, resultProcessingConverter);
+		}
+
+		return rowMapperToUse;
 	}
 
 	@SuppressWarnings("unchecked")

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/support/JdbcQueryLookupStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/support/JdbcQueryLookupStrategy.java
@@ -103,12 +103,11 @@ class JdbcQueryLookupStrategy implements QueryLookupStrategy {
 		try {
 			if (namedQueries.hasQuery(queryMethod.getNamedQueryName()) || queryMethod.hasAnnotatedQuery()) {
 
-				RowMapper<?> mapper = queryMethod.isModifyingQuery() ? null : createMapper(queryMethod);
-				StringBasedJdbcQuery query = new StringBasedJdbcQuery(queryMethod, operations, mapper, converter);
+				StringBasedJdbcQuery query = new StringBasedJdbcQuery(queryMethod, operations, this::createMapper, converter);
 				query.setBeanFactory(beanfactory);
 				return query;
 			} else {
-				return new PartTreeJdbcQuery(context, queryMethod, dialect, converter, operations, createMapper(queryMethod));
+				return new PartTreeJdbcQuery(context, queryMethod, dialect, converter, operations, this::createMapper);
 			}
 		} catch (Exception e) {
 			throw QueryCreationException.create(queryMethod, e);
@@ -116,9 +115,7 @@ class JdbcQueryLookupStrategy implements QueryLookupStrategy {
 	}
 
 	@SuppressWarnings("unchecked")
-	private RowMapper<Object> createMapper(JdbcQueryMethod queryMethod) {
-
-		Class<?> returnedObjectType = queryMethod.getReturnedObjectType();
+	private RowMapper<Object> createMapper(Class<?> returnedObjectType) {
 
 		RelationalPersistentEntity<?> persistentEntity = context.getPersistentEntity(returnedObjectType);
 
@@ -126,19 +123,18 @@ class JdbcQueryLookupStrategy implements QueryLookupStrategy {
 			return (RowMapper<Object>) SingleColumnRowMapper.newInstance(returnedObjectType, converter.getConversionService());
 		}
 
-		return (RowMapper<Object>) determineDefaultMapper(queryMethod);
+		return (RowMapper<Object>) determineDefaultMapper(returnedObjectType);
 	}
 
-	private RowMapper<?> determineDefaultMapper(JdbcQueryMethod queryMethod) {
+	private RowMapper<?> determineDefaultMapper(Class<?> returnedObjectType) {
 
-		Class<?> domainType = queryMethod.getReturnedObjectType();
-		RowMapper<?> configuredQueryMapper = queryMappingConfiguration.getRowMapper(domainType);
+		RowMapper<?> configuredQueryMapper = queryMappingConfiguration.getRowMapper(returnedObjectType);
 
 		if (configuredQueryMapper != null)
 			return configuredQueryMapper;
 
 		EntityRowMapper<?> defaultEntityRowMapper = new EntityRowMapper<>( //
-				context.getRequiredPersistentEntity(domainType), //
+				context.getRequiredPersistentEntity(returnedObjectType), //
 				converter //
 		);
 

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/BasicRelationalConverter.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/BasicRelationalConverter.java
@@ -199,6 +199,11 @@ public class BasicRelationalConverter implements RelationalConverter {
 		return conversionService.convert(value, type.getType());
 	}
 
+	@Override
+	public EntityInstantiators getEntityInstantiators() {
+		return this.entityInstantiators;
+	}
+
 	/**
 	 * Checks whether we have a custom conversion registered for the given value into an arbitrary simple JDBC type.
 	 * Returns the converted value if so. If not, we perform special enum handling or simply return the value as is.

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/RelationalConverter.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/conversion/RelationalConverter.java
@@ -22,6 +22,7 @@ import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.PersistentPropertyAccessor;
 import org.springframework.data.mapping.PreferredConstructor.Parameter;
 import org.springframework.data.mapping.context.MappingContext;
+import org.springframework.data.mapping.model.EntityInstantiators;
 import org.springframework.data.mapping.model.ParameterValueProvider;
 import org.springframework.data.relational.core.mapping.RelationalPersistentEntity;
 import org.springframework.data.relational.core.mapping.RelationalPersistentProperty;
@@ -92,4 +93,12 @@ public interface RelationalConverter {
 	 */
 	@Nullable
 	Object writeValue(@Nullable Object value, TypeInformation<?> type);
+
+	/**
+	 * Return the underlying {@link EntityInstantiators}.
+	 *
+	 * @return
+	 * @since 2.3
+	 */
+	EntityInstantiators getEntityInstantiators();
 }

--- a/src/main/asciidoc/jdbc.adoc
+++ b/src/main/asciidoc/jdbc.adoc
@@ -127,7 +127,7 @@ The Spring Data JDBC repositories support can be activated by an annotation thro
 class ApplicationConfig extends AbstractJdbcConfiguration {                            // <2>
 
     @Bean
-    public DataSource dataSource() {                                                   // <3>
+    DataSource dataSource() {                                                         // <3>
 
         EmbeddedDatabaseBuilder builder = new EmbeddedDatabaseBuilder();
         return builder.setType(EmbeddedDatabaseType.HSQL).build();
@@ -250,13 +250,11 @@ Custom converters can be registered, for types that are not supported by default
 [source,java]
 ----
 @Configuration
-public class DataJdbcConfiguration extends AbstractJdbcConfiguration {
+class DataJdbcConfiguration extends AbstractJdbcConfiguration {
 
     @Override
     public JdbcCustomConversions jdbcCustomConversions() {
-
       return new JdbcCustomConversions(Collections.singletonList(TimestampTzToDateConverter.INSTANCE));
-
     }
 
     @ReadingConverter
@@ -303,7 +301,7 @@ The following example maps the `MyEntity` class to the `CUSTOM_TABLE_NAME` table
 [source,java]
 ----
 @Table("CUSTOM_TABLE_NAME")
-public class MyEntity {
+class MyEntity {
     @Id
     Integer id;
 
@@ -322,7 +320,7 @@ The following example maps the `name` property of the `MyEntity` class to the `C
 ====
 [source,java]
 ----
-public class MyEntity {
+class MyEntity {
     @Id
     Integer id;
 
@@ -340,7 +338,7 @@ In the following example the corresponding table for the `MySubEntity` class has
 ====
 [source,java]
 ----
-public class MyEntity {
+class MyEntity {
     @Id
     Integer id;
 
@@ -348,7 +346,7 @@ public class MyEntity {
     Set<MySubEntity> subEntities;
 }
 
-public class MySubEntity {
+class MySubEntity {
     String name;
 }
 ----
@@ -360,7 +358,7 @@ This additional column name may be customized with the `keyColumn` Element of th
 ====
 [source,java]
 ----
-public class MyEntity {
+class MyEntity {
     @Id
     Integer id;
 
@@ -368,7 +366,7 @@ public class MyEntity {
     List<MySubEntity> name;
 }
 
-public class MySubEntity {
+class MySubEntity {
     String name;
 }
 ----
@@ -388,7 +386,7 @@ Opposite to this behavior `USE_EMPTY` tries to create a new instance using eithe
 ====
 [source,java]
 ----
-public class MyEntity {
+class MyEntity {
 
     @Id
     Integer id;
@@ -397,7 +395,7 @@ public class MyEntity {
     EmbeddedEntity embeddedEntity;
 }
 
-public class EmbeddedEntity {
+class EmbeddedEntity {
     String name;
 }
 ----
@@ -414,7 +412,7 @@ Make use of the shortcuts `@Embedded.Nullable` & `@Embedded.Empty` for `@Embedde
 
 [source,java]
 ----
-public class MyEntity {
+class MyEntity {
 
     @Id
     Integer id;
@@ -610,7 +608,7 @@ The following example shows how to use `@Query` to declare a query method:
 ====
 [source,java]
 ----
-public interface UserRepository extends CrudRepository<User, Long> {
+interface UserRepository extends CrudRepository<User, Long> {
 
   @Query("select firstName, lastName from User u where u.emailAddress = :email")
   User findByEmailAddress(@Param("email") String email);
@@ -828,7 +826,7 @@ For example, the following listener gets invoked before an aggregate gets saved:
 [source,java]
 ----
 @Bean
-public ApplicationListener<BeforeSaveEvent<Object>> loggingSaves() {
+ApplicationListener<BeforeSaveEvent<Object>> loggingSaves() {
 
 	return event -> {
 
@@ -845,7 +843,7 @@ Callback methods will only get invoked for events related to the domain type and
 ====
 [source,java]
 ----
-public class PersonLoadListener extends AbstractRelationalEventListener<Person> {
+class PersonLoadListener extends AbstractRelationalEventListener<Person> {
 
 	@Override
 	protected void onAfterLoad(AfterLoadEvent<Person> personLoad) {
@@ -937,11 +935,11 @@ If you need to tweak transaction configuration for one of the methods declared i
 ====
 [source,java]
 ----
-public interface UserRepository extends CrudRepository<User, Long> {
+interface UserRepository extends CrudRepository<User, Long> {
 
   @Override
   @Transactional(timeout = 10)
-  public List<User> findAll();
+  List<User> findAll();
 
   // Further query method declarations
 }
@@ -959,7 +957,7 @@ The following example shows how to create such a facade:
 [source,java]
 ----
 @Service
-class UserManagementImpl implements UserManagement {
+public class UserManagementImpl implements UserManagement {
 
   private final UserRepository userRepository;
   private final RoleRepository roleRepository;
@@ -999,7 +997,7 @@ To let your query methods be transactional, use `@Transactional` at the reposito
 [source,java]
 ----
 @Transactional(readOnly = true)
-public interface UserRepository extends CrudRepository<User, Long> {
+interface UserRepository extends CrudRepository<User, Long> {
 
   List<User> findByLastname(String lastname);
 
@@ -1035,7 +1033,7 @@ In order to activate auditing, add `@EnableJdbcAuditing` to your configuration, 
 class Config {
 
   @Bean
-  public AuditorAware<AuditableUser> auditorProvider() {
+  AuditorAware<AuditableUser> auditorProvider() {
     return new AuditorAwareImpl();
   }
 }

--- a/src/main/asciidoc/jdbc.adoc
+++ b/src/main/asciidoc/jdbc.adoc
@@ -1,7 +1,7 @@
 [[jdbc.repositories]]
 = JDBC Repositories
 
-This chapter points out the specialties for repository support for JDBC. This builds on the core repository support explained in <<repositories>>.
+This chapter points out the specialties for repository support for JDBC.This builds on the core repository support explained in <<repositories>>.
 You should have a sound understanding of the basic concepts explained there.
 
 [[jdbc.why]]
@@ -695,6 +695,8 @@ You can specify the following return types:
 * `void`
 * `int` (updated record count)
 * `boolean`(whether a record was updated)
+
+include::{spring-data-commons-docs}/repository-projections.adoc[leveloffset=+2]
 
 [[jdbc.mybatis]]
 == MyBatis Integration


### PR DESCRIPTION
JDBC repository methods now support interface and DTO projections by specifying either the projection type as the return type or using generics and providing a Class parameter to query methods.

Closes #971