### PR TITLE
Fix typo in Query Methods documentation

### DIFF
--- a/src/main/asciidoc/jdbc.adoc
+++ b/src/main/asciidoc/jdbc.adoc
@@ -521,7 +521,7 @@ The following table shows the keywords that are supported for query methods:
 | `age BETWEEN from AND to`
 
 | `NotBetween`
-| `findByAgeBetween(int from, int to)`
+| `findByAgeNotBetween(int from, int to)`
 | `age NOT BETWEEN from AND to`
 
 | `In`


### PR DESCRIPTION
Hi there. This fixes a typo in the docs' sample call for one of the query method keywords.


- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [x] You submit test cases (unit or integration tests) that back your changes.
- [x] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
