### PR TITLE
fix flaky test in PartTreeJdbcQueryUnitTests

### DIFF
--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/PartTreeJdbcQueryUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/PartTreeJdbcQueryUnitTests.java
@@ -589,10 +589,12 @@ public class PartTreeJdbcQueryUnitTests {
 				new Object[] { new Address("Hello", "World") });
 		ParametrizedQuery query = jdbcQuery.createQuery(accessor, returnedType);
 
-		String expectedSql = BASE_SELECT + " WHERE (" + TABLE + ".\"USER_STREET\" = :user_street AND " + TABLE
+		String expectedSql1 = BASE_SELECT + " WHERE (" + TABLE + ".\"USER_STREET\" = :user_street AND " + TABLE
 				+ ".\"USER_CITY\" = :user_city)";
+		String expectedSql2 = BASE_SELECT + " WHERE (" + TABLE + ".\"USER_CITY\" = :user_city AND " + TABLE
+				+ ".\"USER_STREET\" = :user_street)";
 
-		assertThat(query.getQuery()).isEqualTo(expectedSql);
+		assertThat(query.getQuery().equals(expectedSql1) || query.getQuery().equals(expectedSql2)).isTrue();
 		assertThat(query.getParameterSource().getValue("user_street")).isEqualTo("Hello");
 		assertThat(query.getParameterSource().getValue("user_city")).isEqualTo("World");
 	}


### PR DESCRIPTION
In `org.springframework.data.jdbc.repository.query.PartTreeJdbcQueryUnitTests`, the test `createsQueryByEmbeddedObject()` is flaky due to the non-deterministic property of `getDeclatedFields()` (please refer [document](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--)). it is internally invoked by `createQuery()`. I fixed by comparing the actual generated query with two possible queries (set as expected queries), when invoking `getQuery()`, it will return either one of two possible result, which eliminates the flakiness.