### PR TITLE
fix flaky tests in RelationalExampleMapperTests

### DIFF
--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlIdentifierParameterSourceUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/SqlIdentifierParameterSourceUnitTests.java
@@ -21,6 +21,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.relational.core.sql.IdentifierProcessing;
 import org.springframework.data.relational.core.sql.SqlIdentifier;
 
+import java.util.Arrays;
+
 /**
  * Tests for {@link SqlIdentifierParameterSource}.
  *
@@ -95,10 +97,11 @@ public class SqlIdentifierParameterSourceUnitTests {
 		parameters2.addValue(SqlIdentifier.unquoted("key3"), 222);
 
 		parameters.addAll(parameters2);
-
+		String[] allKeys = parameters.getParameterNames();
+		Arrays.sort(allKeys);
 		assertSoftly(softly -> {
 
-			softly.assertThat(parameters.getParameterNames()).isEqualTo(new String[] { "key1", "key2", "key3" });
+			softly.assertThat(allKeys).isEqualTo(new String[] { "key1", "key2", "key3" });
 			softly.assertThat(parameters.getValue("key1")).isEqualTo(111);
 			softly.assertThat(parameters.hasValue("key1")).isTrue();
 			softly.assertThat(parameters.getSqlType("key1")).isEqualTo(11);

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/PartTreeJdbcQueryUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/repository/query/PartTreeJdbcQueryUnitTests.java
@@ -591,10 +591,20 @@ public class PartTreeJdbcQueryUnitTests {
 
 		String expectedSql = BASE_SELECT + " WHERE (" + TABLE + ".\"USER_STREET\" = :user_street AND " + TABLE
 				+ ".\"USER_CITY\" = :user_city)";
+		String actualSql = query.getQuery();
 
-		assertThat(query.getQuery()).isEqualTo(expectedSql);
+		assertThat(compareSqlStr(expectedSql, actualSql)).isTrue();
 		assertThat(query.getParameterSource().getValue("user_street")).isEqualTo("Hello");
 		assertThat(query.getParameterSource().getValue("user_city")).isEqualTo("World");
+	}
+
+	private boolean compareSqlStr(String expectedSql, String actualSql) {
+		String[] expected = expectedSql.split("WHERE");
+		String[] actual = actualSql.split("WHERE");
+		if (!expected[0].equals(actual[0])) return false;
+		expected[1] = expected[1].trim().substring(1, expected[1].length() - 2);
+		String[] flakyParts = expected[1].split("AND");
+		return actual[1].contains(flakyParts[0]) && actual[1].contains(flakyParts[1]);
 	}
 
 	@Test // DATAJDBC-318

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/repository/query/RelationalExampleMapperTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/repository/query/RelationalExampleMapperTests.java
@@ -25,7 +25,15 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -33,6 +41,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.domain.Example;
 import org.springframework.data.domain.ExampleMatcher;
 import org.springframework.data.relational.core.mapping.RelationalMappingContext;
+import org.springframework.data.relational.core.query.CriteriaDefinition;
 import org.springframework.data.relational.core.query.Query;
 
 /**
@@ -89,10 +98,11 @@ public class RelationalExampleMapperTests {
 		Example<Person> example = Example.of(person);
 
 		Query query = exampleMapper.getMappedExample(example);
-
-		assertThat(query.getCriteria()) //
-				.map(Object::toString) //
-				.hasValue("(firstname = 'Frodo') AND (lastname = 'Baggins')");
+		Set<String> allPossibleRes = new HashSet<String>(){{
+			add("(firstname = 'Frodo') AND (lastname = 'Baggins')");
+			add("(lastname = 'Baggins') AND (firstname = 'Frodo')");
+		}};
+		assertThat(allPossibleRes).contains(query.getCriteria().map(Object::toString).get());
 	}
 
 	@Test // GH-929
@@ -123,9 +133,11 @@ public class RelationalExampleMapperTests {
 
 		Query query = exampleMapper.getMappedExample(example);
 
-		assertThat(query.getCriteria()) //
-				.map(Object::toString) //
-				.hasValue("(firstname IS NULL OR firstname = 'Bilbo') AND (lastname IS NULL OR lastname = 'Baggins')");
+		Set<String> allPossibleRes = new HashSet<String>(){{
+			add("(firstname IS NULL OR firstname = 'Bilbo') AND (lastname IS NULL OR lastname = 'Baggins')");
+			add("(lastname IS NULL OR lastname = 'Baggins') AND (firstname IS NULL OR firstname = 'Bilbo')");
+		}};
+		assertThat(allPossibleRes).contains(query.getCriteria().map(Object::toString).get());
 	}
 
 	@Test // GH-929
@@ -367,9 +379,11 @@ public class RelationalExampleMapperTests {
 
 		Query query = exampleMapper.getMappedExample(example);
 
-		assertThat(query.getCriteria()) //
-				.map(Object::toString) //
-				.hasValue("(firstname = 'Frodo') OR (lastname = 'Baggins')");
+		Set<String> allPossibleRes = new HashSet<String>(){{
+			add("(firstname = 'Frodo') OR (lastname = 'Baggins')");
+			add("(lastname = 'Baggins') OR (firstname = 'Frodo')");
+		}};
+		assertThat(allPossibleRes).contains(query.getCriteria().map(Object::toString).get());
 	}
 
 	@Test // GH-929
@@ -382,10 +396,11 @@ public class RelationalExampleMapperTests {
 		Example<Person> example = Example.of(person);
 
 		Query query = exampleMapper.getMappedExample(example);
-
-		assertThat(query.getCriteria()) //
-				.map(Object::toString) //
-				.hasValue("(firstname = 'Frodo') AND (secret = 'I have the ring!')");
+		Set<String> allPossibleRes = new HashSet<String>(){{
+			add("(firstname = 'Frodo') AND (secret = 'I have the ring!')");
+			add("(secret = 'I have the ring!') AND (firstname = 'Frodo')");
+		}};
+		assertThat(allPossibleRes).contains(query.getCriteria().map(Object::toString).get());
 	}
 
 	@Test // GH-929
@@ -414,10 +429,15 @@ public class RelationalExampleMapperTests {
 
 		Query query = exampleMapper.getMappedExample(example);
 
-		assertThat(query.getCriteria()) //
-				.map(Object::toString) //
-				.hasValue("(firstname = 'FRODO') AND (lastname = 'baggins') AND (secret = 'I have the ring!')");
-
+		Set<String> allPossibleRes = new HashSet<String>(){{
+			add("(firstname = 'FRODO') AND (lastname = 'baggins') AND (secret = 'I have the ring!')");
+			add("(firstname = 'FRODO') AND (secret = 'I have the ring!') AND (lastname = 'baggins')");
+			add("(lastname = 'baggins') AND (firstname = 'FRODO') AND (secret = 'I have the ring!')");
+			add("(lastname = 'baggins') AND (secret = 'I have the ring!') AND (firstname = 'FRODO')");
+			add("(secret = 'I have the ring!') AND (lastname = 'baggins') AND (firstname = 'FRODO')");
+			add("(secret = 'I have the ring!') AND (firstname = 'FRODO') AND (lastname = 'baggins')");
+		}};
+		assertThat(allPossibleRes).contains(query.getCriteria().map(Object::toString).get());
 	}
 
 	@Data

--- a/spring-data-relational/src/test/java/org/springframework/data/relational/repository/query/RelationalExampleMapperTests.java
+++ b/spring-data-relational/src/test/java/org/springframework/data/relational/repository/query/RelationalExampleMapperTests.java
@@ -98,11 +98,9 @@ public class RelationalExampleMapperTests {
 		Example<Person> example = Example.of(person);
 
 		Query query = exampleMapper.getMappedExample(example);
-		Set<String> allPossibleRes = new HashSet<String>(){{
-			add("(firstname = 'Frodo') AND (lastname = 'Baggins')");
-			add("(lastname = 'Baggins') AND (firstname = 'Frodo')");
-		}};
-		assertThat(allPossibleRes).contains(query.getCriteria().map(Object::toString).get());
+		String actual = query.getCriteria().map(Object::toString).get();
+		String expected = "(firstname = 'Frodo') AND (lastname = 'Baggins')";
+		assertThat(compareStrWithFlakiness(expected, actual, "AND")).isTrue();
 	}
 
 	@Test // GH-929
@@ -132,12 +130,9 @@ public class RelationalExampleMapperTests {
 		Example<Person> example = Example.of(person, matcher);
 
 		Query query = exampleMapper.getMappedExample(example);
-
-		Set<String> allPossibleRes = new HashSet<String>(){{
-			add("(firstname IS NULL OR firstname = 'Bilbo') AND (lastname IS NULL OR lastname = 'Baggins')");
-			add("(lastname IS NULL OR lastname = 'Baggins') AND (firstname IS NULL OR firstname = 'Bilbo')");
-		}};
-		assertThat(allPossibleRes).contains(query.getCriteria().map(Object::toString).get());
+		String actual = query.getCriteria().map(Object::toString).get();
+		String expected = "(firstname IS NULL OR firstname = 'Bilbo') AND (lastname IS NULL OR lastname = 'Baggins')";
+		assertThat(compareStrWithFlakiness(expected, actual, "AND")).isTrue();
 	}
 
 	@Test // GH-929
@@ -378,12 +373,9 @@ public class RelationalExampleMapperTests {
 		Example<Person> example = Example.of(person, matcher);
 
 		Query query = exampleMapper.getMappedExample(example);
-
-		Set<String> allPossibleRes = new HashSet<String>(){{
-			add("(firstname = 'Frodo') OR (lastname = 'Baggins')");
-			add("(lastname = 'Baggins') OR (firstname = 'Frodo')");
-		}};
-		assertThat(allPossibleRes).contains(query.getCriteria().map(Object::toString).get());
+		String actual = query.getCriteria().map(Object::toString).get();
+		String expected = "(firstname = 'Frodo') OR (lastname = 'Baggins')";
+		assertThat(compareStrWithFlakiness(expected, actual, "OR")).isTrue();
 	}
 
 	@Test // GH-929
@@ -396,11 +388,9 @@ public class RelationalExampleMapperTests {
 		Example<Person> example = Example.of(person);
 
 		Query query = exampleMapper.getMappedExample(example);
-		Set<String> allPossibleRes = new HashSet<String>(){{
-			add("(firstname = 'Frodo') AND (secret = 'I have the ring!')");
-			add("(secret = 'I have the ring!') AND (firstname = 'Frodo')");
-		}};
-		assertThat(allPossibleRes).contains(query.getCriteria().map(Object::toString).get());
+		String actual = query.getCriteria().map(Object::toString).get();
+		String expected = "(firstname = 'Frodo') AND (secret = 'I have the ring!')";
+		assertThat(compareStrWithFlakiness(expected, actual, "AND")).isTrue();
 	}
 
 	@Test // GH-929
@@ -428,16 +418,19 @@ public class RelationalExampleMapperTests {
 		Example<Person> example = Example.of(person, matcher);
 
 		Query query = exampleMapper.getMappedExample(example);
+		String actual = query.getCriteria().map(Object::toString).get();
+		String expected = "(firstname = 'FRODO') AND (lastname = 'baggins') AND (secret = 'I have the ring!')";
+		assertThat(compareStrWithFlakiness(expected, actual, "AND")).isTrue();
+	}
 
-		Set<String> allPossibleRes = new HashSet<String>(){{
-			add("(firstname = 'FRODO') AND (lastname = 'baggins') AND (secret = 'I have the ring!')");
-			add("(firstname = 'FRODO') AND (secret = 'I have the ring!') AND (lastname = 'baggins')");
-			add("(lastname = 'baggins') AND (firstname = 'FRODO') AND (secret = 'I have the ring!')");
-			add("(lastname = 'baggins') AND (secret = 'I have the ring!') AND (firstname = 'FRODO')");
-			add("(secret = 'I have the ring!') AND (lastname = 'baggins') AND (firstname = 'FRODO')");
-			add("(secret = 'I have the ring!') AND (firstname = 'FRODO') AND (lastname = 'baggins')");
-		}};
-		assertThat(allPossibleRes).contains(query.getCriteria().map(Object::toString).get());
+	private boolean compareStrWithFlakiness(String expected, String actual, String regex) {
+		String[] flakyParts = expected.split(regex);
+		for (String part : flakyParts) {
+			if (!actual.contains(part)) {
+				return false;
+			}
+		}
+		return true;
 	}
 
 	@Data


### PR DESCRIPTION
In `org.springframework.data.relational.repository.query.RelationalExampleMapperTests`, the tests `queryByExampleEvenHandlesInvisibleFields()`, `queryByExampleSupportsPropertyTransforms()`, `queryByExampleWithFirstnameAndLastname()`, `queryByExampleWithFirstnameOrLastname()`, `queryByExampleWithNullMatchingFirstnameAndLastname()` are all flaky due to the non-deterministic property of `getDeclatedFields()` (please refer [document](https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaredFields--)). it is internally invoked by `getMappedExample()`. I fixed them by generating all possibilities of actual query strings and store them in a `Set`, then  we only need to check if the actual query string is in the `Set`.