### PR TITLE
Fix broken links in documentation

### DIFF
--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -5,7 +5,7 @@ Jens Schauder, Jay Bryant, Mark Paluch, Bastian Wilhelm
 :javadoc-base: https://docs.spring.io/spring-data/jdbc/docs/{revnumber}/api/
 ifdef::backend-epub3[:front-cover-image: image:epub-cover.png[Front Cover,1050,1600]]
 :spring-data-commons-docs: ../../../../../spring-data-commons/src/main/asciidoc
-:spring-framework-docs: https://docs.spring.io/spring-framework/docs/{springVersion}/
+:spring-framework-docs: https://docs.spring.io/spring-framework/docs/{springVersion}/reference/html
 
 (C) 2018-2021 The original authors.
 

--- a/src/main/asciidoc/preface.adoc
+++ b/src/main/asciidoc/preface.adoc
@@ -13,13 +13,13 @@ The rest of the document refers only to Spring Data JDBC features and assumes th
 [[get-started:first-steps:spring]]
 == Learning Spring
 
-Spring Data uses Spring framework's https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/core.html[core] functionality, including:
+Spring Data uses Spring framework's {spring-framework-docs}/core.html[core] functionality, including:
 
-* https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/core.html#beans[IoC] container
-* https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/core.html#validation[type conversion system]
-* https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/core.html#expressions[expression language]
-* https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/integration.html#jmx[JMX integration]
-* https://docs.spring.io/spring/docs/{springVersion}/spring-framework-reference/data-access.html#dao-exceptions[DAO exception hierarchy].
+* {spring-framework-docs}/core.html#beans[IoC] container
+* {spring-framework-docs}/core.html#validation[type conversion system]
+* {spring-framework-docs}/core.html#expressions[expression language]
+* {spring-framework-docs}/integration.html#jmx[JMX integration]
+* {spring-framework-docs}/data-access.html#dao-exceptions[DAO exception hierarchy].
 
 While you need not know the Spring APIs, understanding the concepts behind them is important.
 At a minimum, the idea behind Inversion of Control (IoC) should be familiar, and you should be familiar with whatever IoC container you choose to use.


### PR DESCRIPTION
Resolves #954

`< 5.3 RC1`: https://docs.spring.io/spring-framework/docs/5.3.0-M2/spring-framework-reference/core.html#expressions
`>= 5.3 RC1`: https://docs.spring.io/spring-framework/docs/5.3.0-RC1/reference/html/core.html#expressions

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [ ] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.
- [ ] You submit test cases (unit or integration tests) that back your changes.
- [ ] You added yourself as author in the headers of the classes you touched. Amend the date range in the Apache license header if needed. For new types, add the license header (copy from another file and set the current year only).
