### PR TITLE
Fix missing class issue with H2 version 2.0.202

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-1114-update-H2-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.4.0-1114-update-H2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-1114-update-H2-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.4.0-1114-update-H2-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/dialect/H2TimestampWithTimeZoneToOffsetDateTimeConverter.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/dialect/H2TimestampWithTimeZoneToOffsetDateTimeConverter.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.data.jdbc.core.dialect;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+import org.h2.api.TimestampWithTimeZone;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.convert.ReadingConverter;
+
+/**
+ * Converter converting from an H2 internal representation of a timestamp with time zone to an OffsetDateTime.
+ *
+ * Only required for H2 versions < 2.0
+ * 
+ * @author Jens Schauder
+ * @since 2.7
+ */
+@ReadingConverter
+public enum H2TimestampWithTimeZoneToOffsetDateTimeConverter
+		implements Converter<TimestampWithTimeZone, OffsetDateTime> {
+
+	INSTANCE;
+
+	@Override
+	public OffsetDateTime convert(TimestampWithTimeZone source) {
+
+		long nanosInSecond = 1_000_000_000;
+		long nanosInMinute = nanosInSecond * 60;
+		long nanosInHour = nanosInMinute * 60;
+
+		long hours = (source.getNanosSinceMidnight() / nanosInHour);
+
+		long nanosInHours = hours * nanosInHour;
+		long nanosLeft = source.getNanosSinceMidnight() - nanosInHours;
+		long minutes = nanosLeft / nanosInMinute;
+
+		long nanosInMinutes = minutes * nanosInMinute;
+		nanosLeft -= nanosInMinutes;
+		long seconds = nanosLeft / nanosInSecond;
+
+		long nanosInSeconds = seconds * nanosInSecond;
+		nanosLeft -= nanosInSeconds;
+		ZoneOffset offset = ZoneOffset.ofTotalSeconds(source.getTimeZoneOffsetSeconds());
+
+		return OffsetDateTime.of(source.getYear(), source.getMonth(), source.getDay(), (int) hours, (int) minutes,
+				(int) seconds, (int) nanosLeft, offset);
+	}
+}

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/dialect/JdbcH2DialectTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/dialect/JdbcH2DialectTests.java
@@ -33,7 +33,7 @@ class JdbcH2DialectTests {
 	@Test
 	void TimestampWithTimeZone2OffsetDateTimeConverterConvertsProperly() {
 
-		JdbcH2Dialect.TimestampWithTimeZoneToOffsetDateTimeConverter converter = JdbcH2Dialect.TimestampWithTimeZoneToOffsetDateTimeConverter.INSTANCE;
+		H2TimestampWithTimeZoneToOffsetDateTimeConverter converter = H2TimestampWithTimeZoneToOffsetDateTimeConverter.INSTANCE;
 		long dateValue = 123456789;
 		long timeNanos = 987654321;
 		int timeZoneOffsetSeconds = 4 * 60 * 60;

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-1114-update-H2-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.4.0-1114-update-H2-SNAPSHOT</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
With older versions H2 returned a proprietary  instance from .
We used to support the conversion of that to an .

With the most recent versions  is no longer part of the H2 driver and we only register the converter when we encounter older versions of H2.

Closes #1114
See h2database/h2database#1359