### PR TITLE
Replaces java.sql.Types constants with java.sql.SQLType values. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>org.springframework.data</groupId>
 	<artifactId>spring-data-relational-parent</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-1089-sql-type-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 	<name>Spring Data Relational Parent</name>

--- a/spring-data-jdbc-distribution/pom.xml
+++ b/spring-data-jdbc-distribution/pom.xml
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.4.0-1089-sql-type-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/spring-data-jdbc/pom.xml
+++ b/spring-data-jdbc/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-jdbc</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-1089-sql-type-SNAPSHOT</version>
 
 	<name>Spring Data JDBC</name>
 	<description>Spring Data module for JDBC repositories.</description>
@@ -15,7 +15,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.4.0-1089-sql-type-SNAPSHOT</version>
 	</parent>
 
 	<properties>

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/BasicJdbcConverter.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/BasicJdbcConverter.java
@@ -19,6 +19,7 @@ import java.sql.Array;
 import java.sql.JDBCType;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.SQLType;
 import java.util.Map;
 import java.util.Optional;
 
@@ -170,10 +171,15 @@ public class BasicJdbcConverter extends BasicRelationalConverter implements Jdbc
 	 * @see org.springframework.data.jdbc.core.convert.JdbcConverter#getSqlType(org.springframework.data.relational.core.mapping.RelationalPersistentProperty)
 	 */
 	@Override
+	public SQLType getTargetSqlType(RelationalPersistentProperty property) {
+		return JdbcUtil.targetSqlTypeFor(getColumnType(property));
+	}
+
+	@Override
+	@Deprecated
 	public int getSqlType(RelationalPersistentProperty property) {
 		return JdbcUtil.sqlTypeFor(getColumnType(property));
 	}
-
 	/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.jdbc.core.convert.JdbcConverter#getColumnType(org.springframework.data.relational.core.mapping.RelationalPersistentProperty)
@@ -282,12 +288,19 @@ public class BasicJdbcConverter extends BasicRelationalConverter implements Jdbc
 		return customWriteTarget.isPresent() && customWriteTarget.get().isAssignableFrom(JdbcValue.class);
 	}
 
-	/*
+	@Override
+	@Deprecated
+	public JdbcValue writeJdbcValue(@Nullable Object value, Class<?> columnType, int sqlType) {
+		return writeJdbcValue(value, columnType, JdbcUtil.jdbcTypeFor(sqlType));
+	}
+
+
+		/*
 	 * (non-Javadoc)
 	 * @see org.springframework.data.jdbc.core.convert.JdbcConverter#writeValue(java.lang.Object, java.lang.Class, int)
 	 */
 	@Override
-	public JdbcValue writeJdbcValue(@Nullable Object value, Class<?> columnType, int sqlType) {
+	public JdbcValue writeJdbcValue(@Nullable Object value, Class<?> columnType, SQLType sqlType) {
 
 		JdbcValue jdbcValue = tryToConvertToJdbcValue(value);
 		if (jdbcValue != null) {
@@ -297,7 +310,8 @@ public class BasicJdbcConverter extends BasicRelationalConverter implements Jdbc
 		Object convertedValue = writeValue(value, ClassTypeInformation.from(columnType));
 
 		if (convertedValue == null || !convertedValue.getClass().isArray()) {
-			return JdbcValue.of(convertedValue, JdbcUtil.jdbcTypeFor(sqlType));
+
+			return JdbcValue.of(convertedValue, sqlType);
 		}
 
 		Class<?> componentType = convertedValue.getClass().getComponentType();

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategy.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultDataAccessStrategy.java
@@ -17,8 +17,8 @@ package org.springframework.data.jdbc.core.convert;
 
 import static org.springframework.data.jdbc.core.convert.SqlGenerator.*;
 
-import java.sql.JDBCType;
 import java.sql.ResultSet;
+import java.sql.SQLType;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -546,17 +546,17 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 	private void addConvertedPropertyValue(SqlIdentifierParameterSource parameterSource,
 			RelationalPersistentProperty property, @Nullable Object value, SqlIdentifier name) {
 
-		addConvertedValue(parameterSource, value, name, converter.getColumnType(property), converter.getSqlType(property));
+		addConvertedValue(parameterSource, value, name, converter.getColumnType(property), converter.getTargetSqlType(property));
 	}
 
 	private void addConvertedPropertyValue(SqlIdentifierParameterSource parameterSource, SqlIdentifier name, Object value,
 			Class<?> javaType) {
 
-		addConvertedValue(parameterSource, value, name, javaType, JdbcUtil.sqlTypeFor(javaType));
+		addConvertedValue(parameterSource, value, name, javaType, JdbcUtil.targetSqlTypeFor(javaType));
 	}
 
 	private void addConvertedValue(SqlIdentifierParameterSource parameterSource, @Nullable Object value,
-			SqlIdentifier paramName, Class<?> javaType, int sqlType) {
+								   SqlIdentifier paramName, Class<?> javaType, SQLType sqlType) {
 
 		JdbcValue jdbcValue = converter.writeJdbcValue( //
 				value, //
@@ -567,7 +567,7 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 		parameterSource.addValue( //
 				paramName, //
 				jdbcValue.getValue(), //
-				JdbcUtil.sqlTypeFor(jdbcValue.getJdbcType()));
+				jdbcValue.getJdbcType().getVendorTypeNumber());
 	}
 
 	private void addConvertedPropertyValuesAsList(SqlIdentifierParameterSource parameterSource,
@@ -578,7 +578,7 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 		for (Object id : values) {
 
 			Class<?> columnType = converter.getColumnType(property);
-			int sqlType = converter.getSqlType(property);
+			SQLType sqlType = converter.getTargetSqlType(property);
 
 			jdbcValue = converter.writeJdbcValue(id, columnType, sqlType);
 			convertedIds.add(jdbcValue.getValue());
@@ -586,7 +586,7 @@ public class DefaultDataAccessStrategy implements DataAccessStrategy {
 
 		Assert.state(jdbcValue != null, "JdbcValue must be not null at this point. Please report this as a bug.");
 
-		JDBCType jdbcType = jdbcValue.getJdbcType();
+		SQLType jdbcType = jdbcValue.getJdbcType();
 		int typeNumber = jdbcType == null ? JdbcUtils.TYPE_UNKNOWN : jdbcType.getVendorTypeNumber();
 
 		parameterSource.addValue(paramName, convertedIds, typeNumber);

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultJdbcTypeFactory.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/DefaultJdbcTypeFactory.java
@@ -16,7 +16,7 @@
 package org.springframework.data.jdbc.core.convert;
 
 import java.sql.Array;
-import java.sql.JDBCType;
+import java.sql.SQLType;
 
 import org.springframework.data.jdbc.core.dialect.JdbcArrayColumns;
 import org.springframework.data.jdbc.support.JdbcUtil;
@@ -68,7 +68,7 @@ public class DefaultJdbcTypeFactory implements JdbcTypeFactory {
 
 		Class<?> componentType = arrayColumns.getArrayType(value.getClass());
 
-		JDBCType jdbcType = JdbcUtil.jdbcTypeFor(componentType);
+		SQLType jdbcType = JdbcUtil.targetSqlTypeFor(componentType);
 		Assert.notNull(jdbcType, () -> String.format("Couldn't determine JDBCType for %s", componentType));
 		String typeName = arrayColumns.getArrayTypeName(jdbcType);
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcConverter.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcConverter.java
@@ -16,6 +16,7 @@
 package org.springframework.data.jdbc.core.convert;
 
 import java.sql.ResultSet;
+import java.sql.SQLType;
 
 import org.springframework.data.jdbc.core.mapping.JdbcValue;
 import org.springframework.data.relational.core.conversion.RelationalConverter;
@@ -39,11 +40,23 @@ public interface JdbcConverter extends RelationalConverter {
 	 * to JDBC parameters.
 	 *
 	 * @param value a value as it is used in the object model. May be {@code null}.
-	 * @param type {@link TypeInformation} into which the value is to be converted. Must not be {@code null}.
+	 * @param type {@literal Class} into which the value is to be converted. Must not be {@code null}.
 	 * @param sqlType the type constant from {@link java.sql.Types} to be used if non is specified by a converter.
 	 * @return The converted value wrapped in a {@link JdbcValue}. Guaranteed to be not {@literal null}.
 	 */
 	JdbcValue writeJdbcValue(@Nullable Object value, Class<?> type, int sqlType);
+
+	/**
+	 * Convert a property value into a {@link JdbcValue} that contains the converted value and information how to bind it
+	 * to JDBC parameters.
+	 *
+	 * @param value a value as it is used in the object model. May be {@code null}.
+	 * @param type {@literal Class} into which the value is to be converted. Must not be {@code null}.
+	 * @param sqlType the {@link SQLType} to be used if non is specified by a converter.
+	 * @return The converted value wrapped in a {@link JdbcValue}. Guaranteed to be not {@literal null}.
+	 * @since 2.4
+	 */
+	JdbcValue writeJdbcValue(@Nullable Object value, Class<?> type, SQLType sqlType);
 
 	/**
 	 * Read the current row from {@link ResultSet} to an {@link RelationalPersistentEntity#getType() entity}.
@@ -73,7 +86,7 @@ public interface JdbcConverter extends RelationalConverter {
 	 * top-level array type (e.g. {@code String[][]} returns {@code String[]}).
 	 *
 	 * @return a {@link Class} that is suitable for usage with JDBC drivers.
-	 * @see org.springframework.data.jdbc.support.JdbcUtil#sqlTypeFor(Class)
+	 * @see org.springframework.data.jdbc.support.JdbcUtil#targetSqlTypeFor(Class)
 	 * @since 2.0
 	 */
 	Class<?> getColumnType(RelationalPersistentProperty property);
@@ -85,5 +98,9 @@ public interface JdbcConverter extends RelationalConverter {
 	 * @see java.sql.Types
 	 * @since 2.0
 	 */
+	SQLType getTargetSqlType(RelationalPersistentProperty property);
+
+	@Deprecated
 	int getSqlType(RelationalPersistentProperty property);
+
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcValue.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/convert/JdbcValue.java
@@ -16,6 +16,7 @@
 package org.springframework.data.jdbc.core.convert;
 
 import java.sql.JDBCType;
+import java.sql.SQLType;
 import java.util.Objects;
 
 import org.springframework.lang.Nullable;
@@ -32,11 +33,11 @@ import org.springframework.lang.Nullable;
 @Deprecated
 public final class JdbcValue extends org.springframework.data.jdbc.core.mapping.JdbcValue {
 
-	private JdbcValue(@Nullable Object value, @Nullable JDBCType jdbcType) {
+	private JdbcValue(@Nullable Object value, @Nullable SQLType	jdbcType) {
 		super(value, jdbcType);
 	}
 
-	public static JdbcValue of(@Nullable Object value, @Nullable JDBCType jdbcType) {
+	public static JdbcValue of(@Nullable Object value, @Nullable SQLType jdbcType) {
 		return new JdbcValue(value, jdbcType);
 	}
 }

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/JdbcValue.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/core/mapping/JdbcValue.java
@@ -16,6 +16,7 @@
 package org.springframework.data.jdbc.core.mapping;
 
 import java.sql.JDBCType;
+import java.sql.SQLType;
 import java.util.Objects;
 
 import org.springframework.lang.Nullable;
@@ -31,15 +32,15 @@ import org.springframework.lang.Nullable;
 public class JdbcValue {
 
 	private final Object value;
-	private final JDBCType jdbcType;
+	private final SQLType jdbcType;
 
-	protected JdbcValue(@Nullable Object value, @Nullable JDBCType jdbcType) {
+	protected JdbcValue(@Nullable Object value, @Nullable SQLType jdbcType) {
 
 		this.value = value;
 		this.jdbcType = jdbcType;
 	}
 
-	public static JdbcValue of(@Nullable Object value, @Nullable JDBCType jdbcType) {
+	public static JdbcValue of(@Nullable Object value, @Nullable SQLType jdbcType) {
 		return new JdbcValue(value, jdbcType);
 	}
 
@@ -49,7 +50,7 @@ public class JdbcValue {
 	}
 
 	@Nullable
-	public JDBCType getJdbcType() {
+	public SQLType getJdbcType() {
 		return this.jdbcType;
 	}
 

--- a/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQuery.java
+++ b/spring-data-jdbc/src/main/java/org/springframework/data/jdbc/repository/query/StringBasedJdbcQuery.java
@@ -18,7 +18,7 @@ package org.springframework.data.jdbc.repository.query;
 import static org.springframework.data.jdbc.repository.query.JdbcQueryExecution.*;
 
 import java.lang.reflect.Constructor;
-import java.sql.JDBCType;
+import java.sql.SQLType;
 
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.BeanFactory;
@@ -161,9 +161,9 @@ public class StringBasedJdbcQuery extends AbstractJdbcQuery {
 		Class<?> conversionTargetType = JdbcColumnTypes.INSTANCE.resolvePrimitiveType(parameterType);
 
 		JdbcValue jdbcValue = converter.writeJdbcValue(value, conversionTargetType,
-				JdbcUtil.sqlTypeFor(conversionTargetType));
+				JdbcUtil.targetSqlTypeFor(conversionTargetType));
 
-		JDBCType jdbcType = jdbcValue.getJdbcType();
+		SQLType jdbcType = jdbcValue.getJdbcType();
 		if (jdbcType == null) {
 
 			parameters.addValue(parameterName, jdbcValue.getValue());

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/BasicJdbcConverterUnitTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/core/convert/BasicJdbcConverterUnitTests.java
@@ -136,7 +136,7 @@ public class BasicJdbcConverterUnitTests {
 	void conversionOfPrimitiveArrays() {
 
 		int[] ints = { 1, 2, 3, 4, 5 };
-		JdbcValue converted = converter.writeJdbcValue(ints, ints.getClass(), JdbcUtil.sqlTypeFor(ints.getClass()));
+		JdbcValue converted = converter.writeJdbcValue(ints, ints.getClass(), JdbcUtil.targetSqlTypeFor(ints.getClass()));
 
 		assertThat(converted.getValue()).isInstanceOf(Array.class);
 		assertThat(typeFactory.arraySource).containsExactly(1, 2, 3, 4, 5);

--- a/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/support/JdbcUtilTests.java
+++ b/spring-data-jdbc/src/test/java/org/springframework/data/jdbc/support/JdbcUtilTests.java
@@ -17,7 +17,7 @@ package org.springframework.data.jdbc.support;
 
 import static org.assertj.core.api.Assertions.*;
 
-import java.sql.Types;
+import java.sql.JDBCType;
 import java.time.OffsetDateTime;
 
 import org.junit.jupiter.api.Test;
@@ -31,6 +31,6 @@ class JdbcUtilTests {
 
 	@Test
 	void test() {
-		assertThat(JdbcUtil.sqlTypeFor(OffsetDateTime.class)).isEqualTo(Types.TIMESTAMP_WITH_TIMEZONE);
+		assertThat(JdbcUtil.targetSqlTypeFor(OffsetDateTime.class)).isEqualTo(JDBCType.TIMESTAMP_WITH_TIMEZONE);
 	}
 }

--- a/spring-data-relational/pom.xml
+++ b/spring-data-relational/pom.xml
@@ -6,7 +6,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<artifactId>spring-data-relational</artifactId>
-	<version>2.4.0-SNAPSHOT</version>
+	<version>2.4.0-1089-sql-type-SNAPSHOT</version>
 
 	<name>Spring Data Relational</name>
 	<description>Spring Data Relational support</description>
@@ -14,7 +14,7 @@
 	<parent>
 		<groupId>org.springframework.data</groupId>
 		<artifactId>spring-data-relational-parent</artifactId>
-		<version>2.4.0-SNAPSHOT</version>
+		<version>2.4.0-1089-sql-type-SNAPSHOT</version>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
java.sql.Types constants are int values and therefore make it tedious to read and debug the code.
SQLType values are mostly enum constants which are much nicer to use.