### PR TITLE
Remove unnecessary `toString()` call.

### DIFF
--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/query/Update.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/query/Update.java
@@ -122,6 +122,6 @@ public class Update {
 					String.format("%s = %s", column.toSql(IdentifierProcessing.NONE), o instanceof Number ? o : "'" + o + "'"));
 		});
 
-		return "SET " + joiner.toString();
+		return "SET " + joiner;
 	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/AsteriskFromTable.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/AsteriskFromTable.java
@@ -55,6 +55,6 @@ public class AsteriskFromTable extends AbstractSegment implements Expression {
 			return ((Aliased) table).getAlias() + ".*";
 		}
 
-		return table.toString() + ".*";
+		return table + ".*";
 	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/Between.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/Between.java
@@ -91,6 +91,6 @@ public class Between extends AbstractSegment implements Condition {
 
 	@Override
 	public String toString() {
-		return column.toString() + " BETWEEN " + begin.toString() + " AND " + end.toString();
+		return column + " BETWEEN " + begin + " AND " + end;
 	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/Like.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/Like.java
@@ -80,6 +80,6 @@ public class Like extends AbstractSegment implements Condition {
 
 	@Override
 	public String toString() {
-		return left.toString() + " LIKE " + right.toString();
+		return left + " LIKE " + right;
 	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/OrderByField.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/OrderByField.java
@@ -115,6 +115,6 @@ public class OrderByField extends AbstractSegment {
 	 */
 	@Override
 	public String toString() {
-		return direction != null ? expression.toString() + " " + direction : expression.toString();
+		return direction != null ? expression + " " + direction : expression.toString();
 	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/SimpleCondition.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/SimpleCondition.java
@@ -75,6 +75,6 @@ public class SimpleCondition extends AbstractSegment implements Condition {
 	 */
 	@Override
 	public String toString() {
-		return expression.toString() + " " + comparator + " " + predicate;
+		return expression + " " + comparator + " " + predicate;
 	}
 }

--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/Where.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/Where.java
@@ -38,6 +38,6 @@ public class Where extends AbstractSegment {
 	 */
 	@Override
 	public String toString() {
-		return "WHERE " + condition.toString();
+		return "WHERE " + condition;
 	}
 }


### PR DESCRIPTION
There were few explicit `toString()` calls that are not needed, since `toString()` will be called by default.



- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.