### PR TITLE
`StringBuilder` can be replaced with String concatenation.

### DIFF
--- a/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/AssignValue.java
+++ b/spring-data-relational/src/main/java/org/springframework/data/relational/core/sql/AssignValue.java
@@ -72,7 +72,6 @@ public class AssignValue extends AbstractSegment implements Assignment {
 	@Override
 	public String toString() {
 
-		StringBuilder builder = new StringBuilder();
-		return builder.append(this.column).append(" = ").append(this.value).toString();
+		return this.column + " = " + this.value;
 	}
 }


### PR DESCRIPTION
In this case the usage of `StringBuilder` has no additional benefit, since it is not inside a loop where the jvm may have problems detecting String concatenation that can be optimized. The usage of "simple" String concatenation makes the code more readable and the code will be automatically optimized by the compiler. (So the final result may use `StringBuilder`).

For me see here:
https://stackoverflow.com/questions/1532461/stringbuilder-vs-string-concatenation-in-tostring-in-java

- [x] You have read the [Spring Data contribution guidelines](https://github.com/spring-projects/spring-data-build/blob/master/CONTRIBUTING.adoc).
- [x] You use the code formatters provided [here](https://github.com/spring-projects/spring-data-build/tree/master/etc/ide) and have them applied to your changes. Don’t submit any formatting related changes.